### PR TITLE
Set stdout and stderr to blocking writes

### DIFF
--- a/cucumber.js
+++ b/cucumber.js
@@ -1,4 +1,4 @@
 module.exports = {
-  default: '--tags ~@wip --format summary',
-  wip: '--tags @wip --format summary',
+  default: '--tags ~@wip',
+  wip: '--tags @wip',
 };

--- a/features/support/blocking_std_streams.js
+++ b/features/support/blocking_std_streams.js
@@ -1,0 +1,9 @@
+// Set blocking writes on stderr and stdout to prevent cucumber pretty formatter from getting
+// truncated on failure.
+// see https://github.com/nodejs/node/issues/6456
+
+/*eslint-disable*/
+[process.stdout, process.stderr].forEach((s) => {
+  s && s.isTTY && s._handle && s._handle.setBlocking &&
+    s._handle.setBlocking(true)
+})


### PR DESCRIPTION
Node 6 doesn't currently flush writes to stdout or stderr on exit,
which is causing the cucumber pretty formatter to get truncated.