### PR TITLE
Use forked npm-shrinkwrap-check

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.0",
     "mocha": "^2.4.5",
-    "npm-shrinkwrap-check": "^0.1.0",
+    "npm-shrinkwrap-check": "git+https://git@github.com/gjvis/npm-shrinkwrap-check.git#ignore-nested-package-json-files",
     "zombie": "^4.2.1"
   },
   "engines": {


### PR DESCRIPTION
Avoids false negatives caused by package.json files nested inside dependencies.