### PR TITLE
Consistenly refer to account identifier as accountId

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,7 +48,7 @@ app.use(express.static(path.join(__dirname,
   'vendor', 'govuk_template_mustache_inheritance', 'assets')));
 
 app.use('/', routes);
-app.use('/:id/jobs', jobs);
+app.use('/:accountId/jobs', jobs);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -10,10 +10,11 @@ router.get('/', (req, res) => {
 });
 
 router.get('/:accountId', (req, res, next) => {
+  const accountId = req.params.accountId;
   Jobs
-    .findAllByAccountId(req.params.accountId)
+    .findAllByAccountId(accountId)
     .then((jobs) => res.render('index',
-      { title: 'Dashboard', accountId: req.params.accountId, jobs: jobs.toJSON() }))
+      { title: 'Dashboard', accountId, jobs: jobs.toJSON() }))
     .catch((err) => next(err));
 });
 

--- a/routes/dashboard.js
+++ b/routes/dashboard.js
@@ -5,15 +5,15 @@ const Jobs = require('../models/jobs-model');
 
 /* GET home page. */
 router.get('/', (req, res) => {
-  const id = req.query.id || uuid.v4();
-  res.redirect(`/${id}`);
+  const accountId = req.query.id || uuid.v4();
+  res.redirect(`/${accountId}`);
 });
 
-router.get('/:id', (req, res, next) => {
+router.get('/:accountId', (req, res, next) => {
   Jobs
-    .findAllByAccountId(req.params.id)
+    .findAllByAccountId(req.params.accountId)
     .then((jobs) => res.render('index',
-      { title: 'Dashboard', id: req.params.id, jobs: jobs.toJSON() }))
+      { title: 'Dashboard', accountId: req.params.accountId, jobs: jobs.toJSON() }))
     .catch((err) => next(err));
 });
 

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -7,18 +7,15 @@ router.get('/new', (req, res) => {
 });
 
 router.post('/new', (req, res, next) => {
+  const accountId = req.params.accountId;
   req.checkBody('title', 'Job title is required').notEmpty();
 
   if (req.validationErrors()) {
-    const body = Object.assign(
-      { errors: req.validationErrors() },
-      { accountId: req.params.accountId },
-      req.body
-    );
+    const body = Object.assign({ errors: req.validationErrors(), accountId }, req.body);
     return res.render('jobs-new', body);
   }
-  return new Jobs(Object.assign(req.body, { accountId: req.params.accountId })).save()
-    .then(() => res.redirect(`/${req.params.accountId}`))
+  return new Jobs(Object.assign(req.body, { accountId })).save()
+    .then(() => res.redirect(`/${accountId}`))
     .catch((err) => next(err));
 });
 

--- a/routes/jobs.js
+++ b/routes/jobs.js
@@ -3,18 +3,22 @@ const router = new express.Router({ mergeParams: true });
 const Jobs = require('../models/jobs-model');
 
 router.get('/new', (req, res) => {
-  res.render('jobs-new', { id: req.params.id });
+  res.render('jobs-new', { accountId: req.params.accountId });
 });
 
 router.post('/new', (req, res, next) => {
   req.checkBody('title', 'Job title is required').notEmpty();
 
   if (req.validationErrors()) {
-    const body = Object.assign({ errors: req.validationErrors() }, { id: req.params.id }, req.body);
+    const body = Object.assign(
+      { errors: req.validationErrors() },
+      { accountId: req.params.accountId },
+      req.body
+    );
     return res.render('jobs-new', body);
   }
-  return new Jobs(Object.assign(req.body, { accountId: req.params.id })).save()
-    .then(() => res.redirect(`/${req.params.id}`))
+  return new Jobs(Object.assign(req.body, { accountId: req.params.accountId })).save()
+    .then(() => res.redirect(`/${req.params.accountId}`))
     .catch((err) => next(err));
 });
 

--- a/test/common/page_objects/DashboardPage.js
+++ b/test/common/page_objects/DashboardPage.js
@@ -1,6 +1,6 @@
 const DashboardPage = function DashboardPage(browser) {
   this.browser = browser;
-  this.visit = (id) => browser.visit(`/${id}`);
+  this.visit = (accountId) => browser.visit(`/${accountId}`);
 
   this.clickAddJobButton = () => browser.click('a.button');
   this.jobList = () => browser.text('ul h4');

--- a/test/common/page_objects/DashboardPage.js
+++ b/test/common/page_objects/DashboardPage.js
@@ -1,6 +1,6 @@
 const DashboardPage = function DashboardPage(browser) {
   this.browser = browser;
-  this.visit = (id) => browser.visit(`/?id=${id}`);
+  this.visit = (id) => browser.visit(`/${id}`);
 
   this.clickAddJobButton = () => browser.click('a.button');
   this.jobList = () => browser.text('ul h4');

--- a/views/index.mustache
+++ b/views/index.mustache
@@ -7,7 +7,7 @@
       Add jobs that you're interested or have applied for. You can then track your progress.
     </p>
 
-    <a href="/{{id}}/jobs/new" class="button">+ Add a job</a>
+    <a href="/{{accountId}}/jobs/new" class="button">+ Add a job</a>
 
     <section class="space-top-double">
       <ul>

--- a/views/jobs-new.mustache
+++ b/views/jobs-new.mustache
@@ -9,7 +9,7 @@
       {{/errors }}
     </ul>
 
-    <form action="/{{id}}/jobs/new" method="POST">
+    <form action="/{{accountId}}/jobs/new" method="POST">
       <div class="form-group">
         <label class="form-label" for="job-title">Job title</label>
         <input class="form-control" id="job-title" type="text" name="title" value="{{title}}">


### PR DESCRIPTION
Avoids confusion around "id", particularly in mustache templates