### PR TITLE
Add support for mounting the app under a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ App requires postgresql running locally. You can run it in docker following belo
     $ export DATABASE_URL=postgres://postgres:password@localhost/your_work_search
 
 **Note**: if you are using *docker-machine* your *DATABASE_URL* will be different
-  
+
     $ export DATABASE_URL=postgres://postgres:password@`docker-machine ip`/your_work_search
 
 ### Start the app
@@ -26,7 +26,18 @@ App requires postgresql running locally. You can run it in docker following belo
     & npm run db-migrate
     $ npm run watch
 
-## Resources
+## Mounting the application in a directory
+
+The app will run mounted at "/" by default. To run within a directory, set the
+`EXPRESS_BASE_PATH` environment variable.
+
+For example, to mount the application at "/your-work-search", run:
+
+```sh
+$ EXPRESS_BASE_PATH=/work-you-could-do npm run start
+```
+
+### Resources
 
 * [Zombie.js documentation][zombie docs]
 

--- a/app/app.js
+++ b/app/app.js
@@ -18,13 +18,18 @@ app.engine('mustache', cons.hogan);
 app.set('view engine', 'mustache');
 app.set('views', path.join(__dirname, 'views'));
 
+// run the whole application in a directory
+const basePath = app.locals.basePath = process.env.EXPRESS_BASE_PATH || '';
+const assetPath = `${basePath}/`;
+
 // Middleware to set default layouts.
 // This must be done per request (and not via app.locals) as the Consolidate.js
 // renderer mutates locals.partials :(
 app.use((req, res, next) => {
   // eslint-disable-next-line no-param-reassign
   res.locals = {
-    assetPath: '/',
+    assetPath,
+    basePath,
     partials: {
       layout: 'layouts/main',
       govukTemplate:
@@ -45,12 +50,12 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(validator());
 app.use(cookieParser());
-app.use(express.static(path.join(__dirname, '..', 'dist', 'public')));
-app.use(express.static(path.join(__dirname, '..',
+app.use(assetPath, express.static(path.join(__dirname, '..', 'dist', 'public')));
+app.use(assetPath, express.static(path.join(__dirname, '..',
   'vendor', 'govuk_template_mustache_inheritance', 'assets')));
 
-app.use('/', dashboard);
-app.use('/:accountId/jobs', jobs);
+app.use(`${basePath}/`, dashboard);
+app.use(`${basePath}/:accountId/jobs`, jobs);
 
 // catch 404 and forward to error handler
 app.use((req, res, next) => {

--- a/app/controllers/dashboard.js
+++ b/app/controllers/dashboard.js
@@ -14,8 +14,9 @@ const dashboardJobs = (jobModels) =>
 
 /* GET home page. */
 router.get('/', (req, res) => {
+  const basePath = req.app.locals.basePath;
   const accountId = req.query.id || uuid.v4();
-  res.redirect(`/${accountId}`);
+  res.redirect(`${basePath}/${accountId}`);
 });
 
 router.get('/:accountId', (req, res, next) => {

--- a/app/controllers/jobs.js
+++ b/app/controllers/jobs.js
@@ -26,6 +26,7 @@ router.get('/new', (req, res) => {
 });
 
 router.post('/new', (req, res, next) => {
+  const basePath = req.app.locals.basePath;
   const accountId = req.params.accountId;
   const deadline = req.body.deadline;
   req.checkBody('title', 'Job title is required').notEmpty();
@@ -40,15 +41,17 @@ router.post('/new', (req, res, next) => {
     { deadline: parseDeadline(deadline) });
 
   return new Jobs(jobData).save()
-    .then(() => res.redirect(`/${accountId}`))
+    .then(() => res.redirect(`${basePath}/${accountId}`))
     .catch((err) => next(err));
 });
 
 router.patch('/:jobId', (req, res, next) => {
+  const basePath = req.app.locals.basePath;
+  const accountId = req.params.accountId;
   const jobId = req.params.jobId;
   new Jobs({ id: jobId })
     .save(req.body, { method: 'update', patch: true })
-    .then(() => res.redirect(`/${req.params.accountId}`))
+    .then(() => res.redirect(`${basePath}/${accountId}`))
     .catch((err) => next(err));
 });
 

--- a/app/views/index.mustache
+++ b/app/views/index.mustache
@@ -7,7 +7,7 @@
       Add jobs that you're interested or have applied for. You can then track your progress.
     </p>
 
-    <a href="/{{accountId}}/jobs/new" class="button">+ Add a job</a>
+    <a href="{{basePath}}/{{accountId}}/jobs/new" class="button">+ Add a job</a>
 
     <section class="space-top-double">
       <ul>
@@ -23,7 +23,7 @@
                   <p class="progression-status">{{status}}</p>
                 </div>
               </div>
-              <form action="/{{accountId}}/jobs/{{id}}?_method=PATCH" method="POST">
+              <form action="{{basePath}}/{{accountId}}/jobs/{{id}}?_method=PATCH" method="POST">
                 <div class="grid-row">
                   <div class="form-group">
                     <fieldset>

--- a/app/views/jobs-new.mustache
+++ b/app/views/jobs-new.mustache
@@ -9,7 +9,7 @@
       {{/errors }}
     </ul>
 
-    <form action="/{{accountId}}/jobs/new" method="POST">
+    <form method="POST">
       <div class="form-group">
         <label class="form-label" for="job-title">Job title</label>
         <input class="form-control" id="job-title" type="text" name="title" value="{{title}}">
@@ -56,7 +56,7 @@
       </div>
     </form>
 
-    <p><a href="/" class="link-back">Back</a></p>
+    <p><a href="{{basePath}}/{{accountId}}" class="link-back">Back</a></p>
 
   {{/applicationContent}}
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pretest": "npm-shrinkwrap-check -3 && eslint . && npm run compile && NODE_ENV=test npm run db-migrate",
     "test": "NODE_ENV=test mocha && NODE_ENV=test npm run features",
     "db-migrate": "knex migrate:latest --knexfile db/knexfile.js",
-    "features": "NODE_ENV=test cucumber.js",
+    "features": "NODE_ENV=test cucumber.js && NODE_ENV=test EXPRESS_BASE_PATH=/example-base-path cucumber.js",
     "heroku-postbuild": "npm run compile"
   },
   "// NOTE": [

--- a/test/features/support/world.js
+++ b/test/features/support/world.js
@@ -10,10 +10,17 @@ require('../../../bin/www');  // This starts the web server, and ensures it is o
                               // started once. It is a misuse of "require", and
                               // should be improved.
 
+const basePath = process.env.EXPRESS_BASE_PATH || '';
+
+const visitWithBasePath = (browser) => {
+  const visit = browser.visit.bind(browser);
+  return (url, ...args) => visit(basePath + url, ...args);
+};
 
 function World() {
   this.expect = chai.expect;
   this.browser = new Zombie();
+  this.browser.visit = visitWithBasePath(this.browser);
 
   this.fixtures = new Fixtures();
   this.scenarioData = new ScenarioData();


### PR DESCRIPTION
Setting the EXPRESS_BASE_PATH environment variable will mount the app
within that variable.

Feature tests are now run twice, once without EXPRESS_BASE_PATH set,
and once with it set.

I'm not overly happy about directly access process.env.EXPRESS_BASE_PATH
in `app/app.js` and in `test/features/support/world.js`, any ideas?