### PR TITLE
JobsModel.findAllByAccountId: Refactor sorting and filtering

### DIFF
--- a/app/controllers/dashboard-controller.js
+++ b/app/controllers/dashboard-controller.js
@@ -13,11 +13,11 @@ router.get('/', (req, res) => {
 
 router.get('/:accountId', (req, res, next) => {
   const accountId = req.params.accountId;
-  const sort = req.query.sort;
-  const filter = req.query.filter;
+  const sort = req.query.sort || 'created';
+  const filter = req.query.filter || 'none';
 
   Jobs
-    .findAllByAccountId(accountId, sort, filter)
+    .findAllByAccountId(accountId, { sort, filter })
     .then((jobModels) => res.render('dashboard',
       new DashboardViewModel(accountId, jobModels.serialize(), sort, filter)
     ))

--- a/app/controllers/dashboard-view-model.js
+++ b/app/controllers/dashboard-view-model.js
@@ -61,6 +61,9 @@ module.exports = class DashboardViewModel {
 
   dashboardFilterOptions(filter) {
     return [
+      { value: 'none',
+        // eslint-disable-next-line no-underscore-dangle
+        label: i18n.__('dashboard.filter.none'), selected: filter === 'none' },
       { value: 'week',
         // eslint-disable-next-line no-underscore-dangle
         label: i18n.__('dashboard.filter.week'), selected: filter === 'week' },
@@ -70,9 +73,6 @@ module.exports = class DashboardViewModel {
       { value: 'month',
         // eslint-disable-next-line no-underscore-dangle
         label: i18n.__('dashboard.filter.month'), selected: filter === 'month' },
-      { value: 'none',
-        // eslint-disable-next-line no-underscore-dangle
-        label: i18n.__('dashboard.filter.none'), selected: filter === 'none' },
     ];
   }
 

--- a/app/models/jobs-model.js
+++ b/app/models/jobs-model.js
@@ -23,14 +23,18 @@ module.exports = db.Model.extend(
     hasTimestamps: true,
   },
   {
-    findAllByAccountId(accountId, sort, filter) {
-      const sortOrDefault = sort || 'created';
-      const filterOrDefault = filter || 'none';
+    findAllByAccountId(accountId, options = {}) {
+      let query = this.forge().query({ where: { accountId } });
 
-      return this.forge().query({ where: { accountId } })
-        .where('updated_at', '>', historicDate[filterOrDefault].format('YYYY-MM-DD'))
-        .orderBy(sortRef[sortOrDefault].field, sortRef[sortOrDefault].direction)
-        .fetchAll();
+      if (options.filter) {
+        query = query.where('updated_at', '>', historicDate[options.filter].format('YYYY-MM-DD'));
+      }
+
+      if (options.sort) {
+        query = query.orderBy(sortRef[options.sort].field, sortRef[options.sort].direction);
+      }
+
+      return query.fetchAll();
     },
   }
 );


### PR DESCRIPTION
Make sorting and filtering optional for JobsModel.findAllByAccountId,
allowing the model to be more agnostic what its used for.

Push sorting and filtering defaults to the DashboardController, so that
it can reliably set up a view-model with whatever sorting and filtering
options were applied.

Question: I haven't added additional specs, as this behaviour is all
currently covered by `/test/integration/dashboard.spec.js`. Perhaps
JobsModel.findAllByAccountId needs its own spec?