### PR TITLE
Sample Job data

### DIFF
--- a/scripts/seeds/chef/job_seed.js
+++ b/scripts/seeds/chef/job_seed.js
@@ -5,11 +5,11 @@ const fortnight = moment.duration(2, 'w');
 const month = moment.duration(1, 'M');
 
 exports.seed = function (knex) {
-  return knex('jobs').del() // Deletes ALL existing entries
+  return knex('jobs').where('accountId', 'CHEF-123').del() // Deletes specific account entries
 
     .then(function () {
       return knex('jobs').insert({
-        id: '100',
+        id: '900000100',
         accountId: 'CHEF-123',
         title: 'Sous Chef',
         employer: 'The Green Goblin',
@@ -25,7 +25,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '101',
+        id: '900000101',
         accountId: 'CHEF-123',
         title: 'Chef de Partie',
         employer: 'The Boar’s Shoulder',
@@ -41,7 +41,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '102',
+        id: '900000102',
         accountId: 'CHEF-123',
         title: 'Head Chef',
         employer: 'The Duke’s Arms',
@@ -57,7 +57,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '103',
+        id: '900000103',
         accountId: 'CHEF-123',
         title: 'Commis Chef',
         employer: 'Bubble -employer- Squeak',
@@ -73,7 +73,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '104',
+        id: '900000104',
         accountId: 'CHEF-123',
         title: 'Section Chef',
         employer: 'Hobgoblin Inn',
@@ -89,7 +89,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '105',
+        id: '900000105',
         accountId: 'CHEF-123',
         title: 'Chef de Cuisine',
         employer: 'The Turtle Tavern',
@@ -105,7 +105,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '106',
+        id: '900000106',
         accountId: 'CHEF-123',
         title: 'Pastry Chef',
         employer: 'The Food Factory',
@@ -121,7 +121,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '107',
+        id: '900000107',
         accountId: 'CHEF-123',
         title: 'Sous Chef',
         employer: 'The Red Rabit',
@@ -137,7 +137,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '108',
+        id: '900000108',
         accountId: 'CHEF-123',
         title: 'Chef de Partie',
         employer: 'Squid and Thistle ',
@@ -153,7 +153,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '109',
+        id: '900000109',
         accountId: 'CHEF-123',
         title: 'Head Chef',
         employer: 'The King’s Whistle',
@@ -169,7 +169,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '110',
+        id: '900000110',
         accountId: 'CHEF-123',
         title: 'Commis Chef',
         employer: 'Flying Crab Tavern',
@@ -185,7 +185,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '111',
+        id: '900000111',
         accountId: 'CHEF-123',
         title: 'Section Chef',
         employer: 'The Lost Leprechaun',
@@ -201,7 +201,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '112',
+        id: '900000112',
         accountId: 'CHEF-123',
         title: 'Chef de Cuisine',
         employer: 'The Wax Minotaur',
@@ -217,7 +217,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '113',
+        id: '900000113',
         accountId: 'CHEF-123',
         title: 'Pastry Chef',
         employer: 'Fish and Gravy',
@@ -233,7 +233,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '114',
+        id: '900000114',
         accountId: 'CHEF-123',
         title: 'Sous Chef',
         employer: 'Giggling Grapefruit',
@@ -249,7 +249,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '115',
+        id: '900000115',
         accountId: 'CHEF-123',
         title: 'Chef de Partie',
         employer: 'The Grey Goat',
@@ -265,7 +265,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '116',
+        id: '900000116',
         accountId: 'CHEF-123',
         title: 'Head Chef',
         employer: 'The Fickle Fig',
@@ -281,7 +281,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '117',
+        id: '900000117',
         accountId: 'CHEF-123',
         title: 'Commis Chef',
         employer: 'Petit Pears',
@@ -297,7 +297,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '118',
+        id: '900000118',
         accountId: 'CHEF-123',
         title: 'Section Chef',
         employer: 'The Raging Orchid',
@@ -313,7 +313,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '119',
+        id: '900000119',
         accountId: 'CHEF-123',
         title: 'Chef de Cuisine',
         employer: 'Hedgehog and Cucumber',
@@ -329,7 +329,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '120',
+        id: '900000120',
         accountId: 'CHEF-123',
         title: 'Pastry Chef',
         employer: 'The Fountainer',
@@ -345,7 +345,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '121',
+        id: '900000121',
         accountId: 'CHEF-123',
         title: 'Sous Chef',
         employer: 'Hobnobs Inn',
@@ -361,7 +361,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '122',
+        id: '900000122',
         accountId: 'CHEF-123',
         title: 'Chef de Partie',
         employer: 'Peas -employer- Shortbread',
@@ -377,7 +377,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '123',
+        id: '900000123',
         accountId: 'CHEF-123',
         title: 'Head Chef',
         employer: 'The Queen’s Stead',
@@ -393,7 +393,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '124',
+        id: '900000124',
         accountId: 'CHEF-123',
         title: 'Commis Chef',
         employer: 'The Atrium',

--- a/scripts/seeds/example/job_seed.js
+++ b/scripts/seeds/example/job_seed.js
@@ -4,12 +4,12 @@ const fortnight = moment.duration(2, 'w');
 const month = moment.duration(1, 'M');
 
 exports.seed = function (knex) {
-  return knex('jobs').where('accountId', 'HR-123').del() // Deletes specific account entries
+  return knex('jobs').where('accountId', 'EXAMPLE').del() // Deletes specific account entries
 
     .then(function () {
       return knex('jobs').insert({
-        id: '900000201',
-        accountId: 'HR-123',
+        id: '900000401',
+        accountId: 'EXAMPLE',
         title: 'People Manager',
         employer: 'Paramount Pictures',
         created_at: moment().subtract(month).add(day),
@@ -24,8 +24,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000202',
-        accountId: 'HR-123',
+        id: '900000402',
+        accountId: 'EXAMPLE',
         title: 'Human Resources Advisor',
         employer: 'JRR Events',
         created_at: moment().subtract(month).add(day),
@@ -40,8 +40,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000203',
-        accountId: 'HR-123',
+        id: '900000403',
+        accountId: 'EXAMPLE',
         title: 'HR Administrator',
         employer: 'HRT Management',
         created_at: moment().subtract(month).add(day),
@@ -56,8 +56,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000204',
-        accountId: 'HR-123',
+        id: '900000404',
+        accountId: 'EXAMPLE',
         title: 'HR Advisor',
         employer: 'James Fitzgerald plc',
         created_at: moment().subtract(month).add(day),
@@ -72,8 +72,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000205',
-        accountId: 'HR-123',
+        id: '900000405',
+        accountId: 'EXAMPLE',
         title: 'HR Operations Administrator',
         employer: 'Islington Studios',
         created_at: moment().subtract(month).add(day),
@@ -88,8 +88,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000206',
-        accountId: 'HR-123',
+        id: '900000406',
+        accountId: 'EXAMPLE',
         title: 'Talent Manager',
         employer: 'Joint Operations',
         created_at: moment().subtract(fortnight).add(day),
@@ -104,8 +104,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000207',
-        accountId: 'HR-123',
+        id: '900000407',
+        accountId: 'EXAMPLE',
         title: 'Regional HR Manager',
         employer: 'Snoitulos Solutions',
         created_at: moment().subtract(fortnight).add(day),
@@ -120,8 +120,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000208',
-        accountId: 'HR-123',
+        id: '900000408',
+        accountId: 'EXAMPLE',
         title: 'HR Manager',
         employer: 'Sunzoom Media',
         created_at: moment().subtract(fortnight).add(day),
@@ -136,8 +136,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000209',
-        accountId: 'HR-123',
+        id: '900000409',
+        accountId: 'EXAMPLE',
         title: 'People Manager',
         employer: 'Oswald Filigree -employer- Associates ',
         created_at: moment().subtract(fortnight).add(day),
@@ -152,8 +152,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000210',
-        accountId: 'HR-123',
+        id: '900000410',
+        accountId: 'EXAMPLE',
         title: 'Human Resources Advisor',
         employer: 'Dreamline Pictures',
         created_at: moment().subtract(fortnight).add(day),
@@ -168,8 +168,8 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '900000211',
-        accountId: 'HR-123',
+        id: '900000411',
+        accountId: 'EXAMPLE',
         title: 'HR Administrator',
         employer: 'Surreal Technology',
         created_at: moment().subtract(fortnight).add(day),

--- a/scripts/seeds/knexfile-example.js
+++ b/scripts/seeds/knexfile-example.js
@@ -1,0 +1,30 @@
+const config = require('../../db/knexfile.js');
+module.exports = {
+
+  development: Object.assign(
+    {
+      seeds: {
+        directory: './example',
+      },
+    },
+    config.development
+  ),
+
+  test: Object.assign(
+    {
+      seeds: {
+        directory: './example',
+      },
+    },
+    config.test
+  ),
+
+  production: Object.assign(
+    {
+      seeds: {
+        directory: './example',
+      },
+    },
+    config.production
+  ),
+};

--- a/scripts/seeds/test/job_seed.js
+++ b/scripts/seeds/test/job_seed.js
@@ -1,144 +1,15 @@
 const moment = require('moment');
 const day = moment.duration(1, 'd');
-const week = moment.duration(1, 'w');
 const fortnight = moment.duration(2, 'w');
 const month = moment.duration(1, 'M');
 const quarter = moment.duration(3, 'M');
 
 exports.seed = function (knex) {
-  return knex('jobs').del() // Deletes ALL existing entries
+  return knex('jobs').where('accountId', 'TEST-123').del() // Deletes specific account entries
 
     .then(function () {
       return knex('jobs').insert({
-        id: '900',
-        accountId: 'TEST-123',
-        title: 'Title-900',
-        employer: 'Employer-900',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'interested',
-        status_sort_index: 0,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '901',
-        accountId: 'TEST-123',
-        title: 'Title-901',
-        employer: 'Employer-901',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'interested',
-        status_sort_index: 0,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '902',
-        accountId: 'TEST-123',
-        title: 'Title-902',
-        employer: 'Employer-902',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'applied',
-        status_sort_index: 1,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '903',
-        accountId: 'TEST-123',
-        title: 'Title-903',
-        employer: 'Employer-903',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'applied',
-        status_sort_index: 1,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '904',
-        accountId: 'TEST-123',
-        title: 'Title-904',
-        employer: 'Employer-904',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'interview',
-        status_sort_index: 2,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '905',
-        accountId: 'TEST-123',
-        title: 'Title-905',
-        employer: 'Employer-905',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'interview',
-        status_sort_index: 2,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '906',
-        accountId: 'TEST-123',
-        title: 'Title-906',
-        employer: 'Employer-906',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'result',
-        status_sort_index: 3,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '907',
-        accountId: 'TEST-123',
-        title: 'Title-907',
-        employer: 'Employer-907',
-        created_at: moment().subtract(week).add(day),
-        updated_at: moment().subtract(week).add(day),
-        sourceType: 'online',
-        sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
-        deadline: moment().subtract(week).add(fortnight),
-        rating: '3',
-        status: 'result',
-        status_sort_index: 3,
-      });
-    })
-    .then(function () {
-      return knex('jobs').insert({
-        id: '908',
+        id: '900000908',
         accountId: 'TEST-123',
         title: 'Title-908',
         employer: 'Employer-908',
@@ -154,7 +25,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '909',
+        id: '900000909',
         accountId: 'TEST-123',
         title: 'Title-909',
         employer: 'Employer-909',
@@ -170,7 +41,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '910',
+        id: '900000910',
         accountId: 'TEST-123',
         title: 'Title-910',
         employer: 'Employer-910',
@@ -186,7 +57,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '911',
+        id: '900000911',
         accountId: 'TEST-123',
         title: 'Title-911',
         employer: 'Employer-911',
@@ -202,7 +73,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '912',
+        id: '900000912',
         accountId: 'TEST-123',
         title: 'Title-912',
         employer: 'Employer-912',
@@ -218,7 +89,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '913',
+        id: '900000913',
         accountId: 'TEST-123',
         title: 'Title-913',
         employer: 'Employer-913',
@@ -234,7 +105,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '914',
+        id: '900000914',
         accountId: 'TEST-123',
         title: 'Title-914',
         employer: 'Employer-914',
@@ -250,7 +121,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '915',
+        id: '900000915',
         accountId: 'TEST-123',
         title: 'Title-915',
         employer: 'Employer-915',
@@ -266,7 +137,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '916',
+        id: '900000916',
         accountId: 'TEST-123',
         title: 'Title-916',
         employer: 'Employer-916',
@@ -282,7 +153,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '917',
+        id: '900000917',
         accountId: 'TEST-123',
         title: 'Title-917',
         employer: 'Employer-917',
@@ -298,7 +169,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '918',
+        id: '900000918',
         accountId: 'TEST-123',
         title: 'Title-918',
         employer: 'Employer-918',
@@ -314,7 +185,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '919',
+        id: '900000919',
         accountId: 'TEST-123',
         title: 'Title-919',
         employer: 'Employer-919',
@@ -330,7 +201,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '920',
+        id: '900000920',
         accountId: 'TEST-123',
         title: 'Title-920',
         employer: 'Employer-920',
@@ -346,7 +217,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '921',
+        id: '900000921',
         accountId: 'TEST-123',
         title: 'Title-921',
         employer: 'Employer-921',
@@ -362,7 +233,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '922',
+        id: '900000922',
         accountId: 'TEST-123',
         title: 'Title-922',
         employer: 'Employer-922',
@@ -378,7 +249,7 @@ exports.seed = function (knex) {
     })
     .then(function () {
       return knex('jobs').insert({
-        id: '923',
+        id: '900000923',
         accountId: 'TEST-123',
         title: 'Title-923',
         employer: 'Employer-923',


### PR DESCRIPTION
Prevent sample data for DB from affecting other job entries.  Number ranges changed so sample data may be repeatedly loaded into Stage and Prod environments.