### PR TITLE
Hide timeline on mobile view

### DIFF
--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -6,6 +6,7 @@
 
 //variables
 $space_size: 10px;
+$timeline_min_width: 912px;
 
 // layout
 .space-top-double {
@@ -176,4 +177,10 @@ button.link-button {
 .panel-indent {
     border-left: 4px solid #bfc1c3;
     padding: 10px 0 10px 15px;
+}
+
+@media only screen and (max-width: $timeline_min_width - 1) {
+  .timeline {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Timeline is not visible on view ports narrower then **912px** - which is when implementation of our timeline is starting to look bad. 

![timeline-mobile](https://cloud.githubusercontent.com/assets/174123/21607001/2b4ce196-d1ab-11e6-96db-8d9d71ef994f.gif)


## Missing tests
Currently `zombiejs` is not supporting changing view ports https://github.com/assaf/zombie/issues/920
