### PR TITLE
Redirect to add a job if no jobs added

### DIFF
--- a/app/controllers/dashboard-controller.js
+++ b/app/controllers/dashboard-controller.js
@@ -18,15 +18,21 @@ router.get('/', (req, res) => {
 
 router.get('/:accountId', (req, res, next) => {
   const accountId = req.params.accountId;
+  const basePath = req.app.locals.basePath;
   const focus = req.query.focus;
   const sort = req.query.sort || 'created';
 
   Jobs
     .findAllByAccountId(accountId, { sort })
-    .then((findJobsResult) => res.render('dashboard',
-      new DashboardViewModel(
-        accountId, findJobsResult.jobs, findJobsResult.totalSavedJobs, sort, focus)
-    ))
+    .then((findJobsResult) => {
+      if (findJobsResult.jobs.length > 0) {
+        res.render('dashboard', new DashboardViewModel(
+            accountId, findJobsResult.jobs, findJobsResult.totalSavedJobs, sort, focus)
+        );
+      } else {
+        res.redirect(`${basePath}/${accountId}/jobs/new`);
+      }
+    })
     .catch((err) => next(err));
 });
 

--- a/test/common/page_objects/dashboard-page.js
+++ b/test/common/page_objects/dashboard-page.js
@@ -43,7 +43,6 @@ const DashboardPage = function DashboardPage(browser) {
         .match(/size-(\d+)/)[1]
     );
 
-  this.firstUseHelpDisplayed = () => browser.assert.elements('#first-use-help', 1);
   this.hasJobHelpDisplayed = () => browser.assert.elements('#has-job-help', 1);
 
   this.isSortVisible = () => browser.query('#sort') != null;

--- a/test/features/step_definitions/add_job_steps.js
+++ b/test/features/step_definitions/add_job_steps.js
@@ -6,7 +6,6 @@ module.exports = function () {
   function addJob(job, accountId) {
     return this.dashboardPage
       .visit(accountId)
-      .then(() => this.dashboardPage.clickAddJobButton())
       .then(() => this.addJobPage.fillJobApplication(Object.assign(this.fixtures.sampleJob, job)));
   }
 

--- a/test/integration/dashboard.spec.js
+++ b/test/integration/dashboard.spec.js
@@ -265,7 +265,9 @@ describe('Dashboard', () => {
 
   describe('page outline', () => {
     beforeEach(function () {
-      return helper.cleanDb().then(() => dashboardPage.visit(accountId));
+      return helper.cleanDb()
+        .then(() => createJob())
+        .then(() => dashboardPage.visit(accountId));
     });
 
     it('should contain valid google tag manager data', () =>
@@ -274,10 +276,6 @@ describe('Dashboard', () => {
 
     it('should have correct title', () =>
       expect(dashboardPage.browser.text('title')).to.equal('Your work search')
-    );
-
-    it('should have correct help when no jobs have been entered', () =>
-      expect(dashboardPage.firstUseHelpDisplayed())
     );
 
     it('should have correct help when jobs have been entered', () =>

--- a/test/integration/entrypoints.spec.js
+++ b/test/integration/entrypoints.spec.js
@@ -7,6 +7,7 @@ const dashboardPage = helper.dashboardPage;
 describe('Entrypoints', () => {
   const accountId = uuid.v4();
   const dashboardUrl = `/${accountId}`;
+  const addJobUrl = `/${accountId}/jobs/new`;
   const introductionUrl = `/${accountId}/introduction`;
 
   describe('Access the tool with my account id BEFORE ive added a job', () => {
@@ -20,14 +21,16 @@ describe('Entrypoints', () => {
     );
   });
 
-  describe('Access the tool with my account id AFTER ive added a job', () => {
-    before(() =>
-      helper.cleanDb()
-      .then(() => helper.createJobsInDb(helper.sampleJob({ accountId: `${accountId}` })))
-    );
+  describe('Access dashboard', () => {
+    beforeEach(() => helper.cleanDb());
 
-    it('should see the dashboard page', () =>
+    it('should redirect to add a job page if no job added yet', () =>
       browser.visit(`/${accountId}`)
+        .then(() => browser.assert.url({ pathname: addJobUrl }))
+    );
+    it('should display dashboard page if jobs already added', () =>
+      helper.createJobsInDb(helper.sampleJob({ accountId: `${accountId}` }))
+        .then(() => browser.visit(`/${accountId}`))
         .then(() => browser.assert.url({ pathname: dashboardUrl }))
         .then(() => expect(dashboardPage.jobCount()).to.equal(1))
     );

--- a/test/integration/introduction.spec.js
+++ b/test/integration/introduction.spec.js
@@ -19,10 +19,10 @@ describe('Introduction page', () => {
       .then(() => expect(googleTagManagerHelper.getAccountVariable()).to.equal(accountId))
     );
 
-    it('should link to the dashboard', () =>
+    it('should link to add a job page', () =>
       introductionPage.visit(accountId)
       .then(() => introductionPage.clickNext())
-      .then(() => expect(introductionPage.browserPath()).to.equal(`/${accountId}`))
+      .then(() => expect(introductionPage.browserPath()).to.equal(`/${accountId}/jobs/new`))
     );
   });
 });


### PR DESCRIPTION
User is automatically redirected to `add a job` page from dashboard if he hasn't added any jobs yet.
First use flow as follows:
Introduction page -> Add a Job Page

Preview link: https://your-work-search-pr-127.herokuapp.com/416fef37-4a03-4843-8bb4-1b692046565c/introduction