### PR TITLE
Add initial progression section to Add a job page

### DIFF
--- a/app/controllers/add-job-view-model.js
+++ b/app/controllers/add-job-view-model.js
@@ -1,4 +1,6 @@
 const i18n = require('i18n');
+const progression = require('../models/progression');
+const progressionDecorator = require('./progression-view-decorator');
 /* eslint-disable no-underscore-dangle */
 
 class AddJobViewModel {
@@ -20,6 +22,7 @@ class AddJobViewModel {
 
     this.errors = validationErrors;
     this.isSourceUrlHidden = body.sourceType !== 'online';
+    this.progression = progressionDecorator.decorate(progression.getInitialSubset(), this.status);
   }
 
   addCheckedFlag(options, checkedValue) {

--- a/app/controllers/dashboard-view-model.js
+++ b/app/controllers/dashboard-view-model.js
@@ -28,7 +28,7 @@ module.exports = class DashboardViewModel {
   }
 
   dashboardJobProgression(job) {
-    return progression.map((status) => ({
+    return progression.getAllIds().map((status) => ({
       name: status,
       isChecked: (job.status === status),
       // eslint-disable-next-line no-underscore-dangle

--- a/app/controllers/jobs-controller.js
+++ b/app/controllers/jobs-controller.js
@@ -5,6 +5,7 @@ const AddJobViewModel = require('./add-job-view-model');
 const UpdateJobViewModel = require('./update-job-view-model');
 const progression = require('../models/progression');
 const i18n = require('i18n');
+/* eslint-disable no-underscore-dangle */
 
 function buildQueryParams(job) {
   const params = { focus: job.id };
@@ -22,18 +23,17 @@ router.get('/new', (req, res) => {
 router.post('/new', (req, res, next) => {
   const basePath = req.app.locals.basePath;
   const accountId = req.params.accountId;
-  req.checkBody('title', 'Job title is required').notEmpty();
+  req.checkBody('title', i18n.__('validation.job-title-empty')).notEmpty();
+  req.checkBody('status', i18n.__('validation.status-empty')).notEmpty();
 
   if (req.validationErrors()) {
     return res.render('add-job',
       new AddJobViewModel(accountId, req.body, req.validationErrors()));
   }
 
-  const initialProgression = progression.getInitial();
   const jobData = Object.assign({}, req.body, {
     accountId,
-    status: initialProgression.id,
-    status_sort_index: initialProgression.order,
+    status_sort_index: progression.getById(req.body.status).order,
   });
 
   return new Jobs(jobData).save()
@@ -85,7 +85,6 @@ router.delete('/:jobId', (req, res, next) => {
   return new Jobs({ id: jobId })
     .fetch()
     .then(job => {
-      // eslint-disable-next-line no-underscore-dangle
       const description = i18n.__('confirmation.jobRemoved', { jobTitle: job.get('title') });
       return job.destroy()
         .then(() => res.redirect(

--- a/app/controllers/jobs-controller.js
+++ b/app/controllers/jobs-controller.js
@@ -29,10 +29,11 @@ router.post('/new', (req, res, next) => {
       new AddJobViewModel(accountId, req.body, req.validationErrors()));
   }
 
+  const initialProgression = progression.getInitial();
   const jobData = Object.assign({}, req.body, {
     accountId,
-    status: progression[0],
-    status_sort_index: 0,
+    status: initialProgression.id,
+    status_sort_index: initialProgression.order,
   });
 
   return new Jobs(jobData).save()
@@ -65,7 +66,7 @@ router.patch('/:jobId', (req, res, next) => {
   const updateData = req.body;
 
   if (updateData.status) {
-    updateData.status_sort_index = progression.indexOf(updateData.status) || 0;
+    updateData.status_sort_index = progression.getById(updateData.status).order;
   }
 
   return new Jobs({ id: jobId })

--- a/app/controllers/progression-view-decorator.js
+++ b/app/controllers/progression-view-decorator.js
@@ -5,7 +5,7 @@ class ProgressionViewDecorator {
       name: status,
       isChecked: (selectedStatus === status),
       // eslint-disable-next-line no-underscore-dangle
-      label: i18n.__(`progression.${status}`),
+      label: i18n.__(`progression.long.${status}`),
     }));
   }
 }

--- a/app/controllers/progression-view-decorator.js
+++ b/app/controllers/progression-view-decorator.js
@@ -1,0 +1,13 @@
+const i18n = require('i18n');
+class ProgressionViewDecorator {
+  decorate(progressionIds, selectedStatus) {
+    return progressionIds.map((status) => ({
+      name: status,
+      isChecked: (selectedStatus === status),
+      // eslint-disable-next-line no-underscore-dangle
+      label: i18n.__(`progression.${status}`),
+    }));
+  }
+}
+
+module.exports = new ProgressionViewDecorator();

--- a/app/controllers/update-job-view-model.js
+++ b/app/controllers/update-job-view-model.js
@@ -1,6 +1,5 @@
-const i18n = require('i18n');
 const progression = require('../models/progression');
-/* eslint-disable no-underscore-dangle */
+const progressionDecorator = require('./progression-view-decorator');
 
 class UpdateJobViewModel {
   constructor(accountId, job, basePath) {
@@ -10,18 +9,8 @@ class UpdateJobViewModel {
 
     const ratingOptionList = [5, 4, 3, 2, 1].map(value => ({ value }));
     this.ratingOptions = this.addCheckedFlag(ratingOptionList, job.rating);
-    this.progression = this.jobProgression();
+    this.progression = progressionDecorator.decorate(progression.getAllIds(), this.status);
   }
-
-  jobProgression() {
-    return progression.getAllIds().map((status) => ({
-      name: status,
-      isChecked: (this.status === status),
-      // eslint-disable-next-line no-underscore-dangle
-      label: i18n.__(`progression.${status}`),
-    }));
-  }
-
   addCheckedFlag(options, checkedValue) {
     return options.map(opt => Object.assign(opt, { isChecked: opt.value === checkedValue }));
   }

--- a/app/controllers/update-job-view-model.js
+++ b/app/controllers/update-job-view-model.js
@@ -14,7 +14,7 @@ class UpdateJobViewModel {
   }
 
   jobProgression() {
-    return progression.map((status) => ({
+    return progression.getAllIds().map((status) => ({
       name: status,
       isChecked: (this.status === status),
       // eslint-disable-next-line no-underscore-dangle

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -78,5 +78,9 @@
     },
     "linkBack": "Cancel",
     "deleteButton": "Delete job"
+  },
+  "validation": {
+    "job-title-empty": "Job title is required",
+    "status-empty": "Where are you in the process is required"
   }
 }

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -30,7 +30,13 @@
     "interested": "Interested",
     "applied": "Applied",
     "interview": "Interview",
-    "result": "Result"
+    "result": "Result",
+    "long": {
+      "interested": "Interested",
+      "applied": "Applied",
+      "interview": "Going for an interview",
+      "result": "Result"
+    }
   },
   "addJob": {
     "form": {

--- a/app/models/progression.js
+++ b/app/models/progression.js
@@ -1,6 +1,24 @@
-module.exports = [
-  'interested',
-  'applied',
-  'interview',
-  'result',
-];
+class Progression {
+  constructor() {
+    this.model = [
+      { id: 'interested', order: 0 },
+      { id: 'applied', order: 1 },
+      { id: 'interview', order: 2 },
+      { id: 'result', order: 3 },
+    ];
+  }
+
+  getAllIds() {
+    return this.model.map(item => item.id);
+  }
+
+  getInitial() {
+    return this.model[0];
+  }
+
+  getById(id) {
+    return this.model.find(item => item.id === id);
+  }
+}
+
+module.exports = new Progression();

--- a/app/models/progression.js
+++ b/app/models/progression.js
@@ -12,12 +12,12 @@ class Progression {
     return this.model.map(item => item.id);
   }
 
-  getInitial() {
-    return this.model[0];
-  }
-
   getById(id) {
     return this.model.find(item => item.id === id);
+  }
+
+  getInitialSubset() {
+    return this.model.slice(0, 3).map(item => item.id);
   }
 }
 

--- a/app/views/add-job.mustache
+++ b/app/views/add-job.mustache
@@ -23,6 +23,19 @@
         <input class="form-control" id="job-employer" type="text" name="employer" value="{{employer}}">
       </div>
 
+      <fieldset data-test="progression">
+        <legend class="heading-medium">{{#__}}updateJob.form.progress{{/__}}</legend>
+        {{#progression}}
+          <div class="form-group">
+
+            <label class="block-label selection-button-radio">{{label}}
+              <input type="radio" value="{{name}}" name="status"
+                     {{#isChecked}}checked{{/isChecked}}>
+            </label>
+          </div>
+        {{/progression}}
+      </fieldset>
+
       <fieldset class="form-group">
         <legend class="heading-medium">{{#__}}addJob.form.sourceType{{/__}}</legend>
 

--- a/test/common/page_objects/add-job-page.js
+++ b/test/common/page_objects/add-job-page.js
@@ -1,14 +1,16 @@
 const AddJobPage = function AddJobPage(browser) {
   this.browser = browser;
 
-  this.fillJobApplication = (data) =>
-    browser
-      .fill('[name="title"]', data.title)
+  this.fillJobApplication = (data) => {
+    this.fillTitle(data.title);
+    this.setJobProgression(data.status);
+    return browser
       .fill('[name="employer"]', data.employer)
       .choose(`#job-sourceType-${data.sourceType}`)
       .fill('[name="sourceUrl"]', data.sourceUrl)
       .choose(`#job-rating-${data.rating}`)
       .pressButton('input[type=submit]');
+  };
 
   this.getValidationError = () => browser.text('#validation-errors');
 
@@ -26,8 +28,14 @@ const AddJobPage = function AddJobPage(browser) {
       sourceType: browser.field('[name="sourceType"][checked]').value,
       sourceUrl: browser.field('[name="sourceUrl"]').value,
       rating: browser.field('[name="rating"][checked]').value,
+      status: browser.field('[data-test="progression"] input[checked]').value,
     });
   this.fillTitle = title => browser.fill('[name="title"]', title);
+  this.setJobProgression = (status) => browser
+    .click(`[data-test="progression"] input[value="${status}"]`);
+  this.getJobProgressionOptions = () =>
+    browser.queryAll('[data-test="progression"] input')
+      .map(i => i.value);
   this.submit = () => browser.pressButton('input[type=submit]');
 };
 

--- a/test/features/add_a_job.feature
+++ b/test/features/add_a_job.feature
@@ -3,15 +3,6 @@ Feature: Add a job
   I want to report jobs I am interested in or applying for
   so that I can continue to receive UC and avoid sanctions
 
-  Scenario: Add an application
-    When I add a job application
-    Then it should show on my dashboard
-    And it should be be at the beginning of the job application progression
-
-  Scenario: Validation
-    When I add a job application without a title
-    Then I should see a validation error
-
   Scenario: Multiple claimants add job application
     When multiple claimants have added job applications to their accounts
     Then each claimant should only be able to see their respective job applications

--- a/test/features/step_definitions/account_steps.js
+++ b/test/features/step_definitions/account_steps.js
@@ -1,6 +1,6 @@
 const JobsModel = require('../../../app/models/jobs-model');
 const moment = require('moment');
-const initialStatus = require('../../../app/models/progression')[0];
+const initialStatus = require('../../../app/models/progression').getAllIds()[0];
 
 function jobDataFormattedForDb(job) {
   return Object.assign({}, job,

--- a/test/features/step_definitions/add_job_steps.js
+++ b/test/features/step_definitions/add_job_steps.js
@@ -12,28 +12,9 @@ module.exports = function () {
 
   function addJobForClaimant(claimant) {
     this.scenarioData.addClaimant(claimant);
-    return addJob.call(this, { title: claimantJobTitle(claimant) },
+    return addJob.call(this, { title: claimantJobTitle(claimant), status: 'applied' },
       this.scenarioData.idFor(claimant));
   }
-
-  this.When(/^I add a job application$/, function () {
-    this.scenarioData.addedJob = this.fixtures.sampleJob;
-    return addJob.call(this, this.fixtures.sampleJob, this.scenarioData.accountIdentifier);
-  });
-
-  this.When(/^I add a job application without a title$/, function () {
-    return addJob.call(this, { title: '' }, this.scenarioData.accountIdentifier);
-  });
-
-  this.Then(/^I should see a validation error$/, function () {
-    return this.expect(this.addJobPage.getValidationError()).to.equal('Job title is required');
-  });
-
-  this.Then(/^it should show on my dashboard$/, function () {
-    return this
-      .expect(this.dashboardPage.jobList())
-      .to.contain(this.scenarioData.addedJob.title);
-  });
 
   this.When(/^multiple claimants have added job applications to their accounts$/, function () {
     return addJobForClaimant.call(this, 'John').then(() => addJobForClaimant.call(this, 'Anna'));

--- a/test/integration/add-job-page.spec.js
+++ b/test/integration/add-job-page.spec.js
@@ -36,6 +36,11 @@ describe('Add a job page', () => {
     it('should contain valid google tag manager data', () =>
       expect(googleTagManagerHelper.getAccountVariable()).to.equal(accountId)
     );
+
+    it('should display subset of progression statuses', () =>
+      expect(addJobPage.getJobProgressionOptions())
+        .to.eql(['interested', 'applied', 'interview'])
+    );
   });
 
   describe('successful job creation', () => {
@@ -61,7 +66,8 @@ describe('Add a job page', () => {
     );
 
     it('should display newly created job progression status', () =>
-      expect(dashboardPage.getJobProgressionStatus(newlyCreatedJob())).to.equal('Interested')
+      expect(dashboardPage.getJobProgressionStatus(newlyCreatedJob()))
+        .to.equal(helper.labels.progression[sampleJob.status])
     );
 
     it('should display newly created job rating', () =>
@@ -76,16 +82,28 @@ describe('Add a job page', () => {
   describe('validation error', () => {
     const form = {
       title: '', employer: 'Dwp', sourceType: 'online', sourceUrl: 'http://indeed.com',
-      rating: '2',
+      rating: '2', status: 'applied',
     };
-
     before(() => addJobPage.visit(accountId));
 
     it('should prepopulate filled form fields after error', () =>
-      Promise.resolve(expect(addJobPage.employerFieldValue()).to.equal(''))
-        .then(() => addJobPage.fillJobApplication(form))
+      addJobPage.fillJobApplication(form)
         .then(() => expect(addJobPage.formValues()).to.eql(form))
     );
+
+    describe('for empty form', () => {
+      before(() =>
+        addJobPage.visit(accountId)
+          .then(() => addJobPage.submit())
+      );
+
+      it('should show title is required error', () =>
+        expect(addJobPage.getValidationError()).to.contain('Job title is required')
+      );
+      it('should show jog progression is required error', () =>
+        expect(addJobPage.getValidationError())
+          .to.contain('Where are you in the process is required')
+      );
+    });
   });
 });
-

--- a/test/integration/dashboard.spec.js
+++ b/test/integration/dashboard.spec.js
@@ -190,6 +190,7 @@ describe('Dashboard', () => {
         dashboardPage.sort(SEED_ACCOUNT_ID, 'status')
           .then(() => dashboardPage.clickAddJobButton())
           .then(() => helper.addJobPage.fillTitle('E-'))
+          .then(() => helper.addJobPage.setJobProgression('applied'))
           .then(() => helper.addJobPage.submit())
       );
       it('should display jobs in default order', () =>

--- a/test/integration/support/integration-spec-helper.js
+++ b/test/integration/support/integration-spec-helper.js
@@ -9,6 +9,7 @@ const AddJobPage = require('../../common/page_objects/add-job-page');
 const UpdateJobPage = require('../../common/page_objects/update-job-page');
 const ConfirmationPage = require('../../common/page_objects/confirmation-page');
 const GoogleTagManagerHelper = require('../../common/page_objects/google-tag-manager-helper');
+const labels = require('../../../app/locales/en.json');
 
 
 process.env.GOOGLE_TAG_MANAGER_ID = 'fake-id';
@@ -31,6 +32,7 @@ module.exports = Object.assign(
     confirmationPage: new ConfirmationPage(browser),
     dashboardPage: new DashboardPage(browser),
     introductionPage: new IntroductionPage(browser),
+    labels,
   },
   dbHelper
 );

--- a/test/integration/update-job.spec.js
+++ b/test/integration/update-job.spec.js
@@ -63,7 +63,7 @@ describe('Update a job', () => {
   });
 
   describe('update job details', () => {
-    progression.forEach(s => {
+    progression.getAllIds().forEach(s => {
       it(`should update job progress to ${s}`, () =>
         updateJobPage.setJobProgression(s)
           .then(() => updateJobPage.clickSave())

--- a/test/integration/update-job.spec.js
+++ b/test/integration/update-job.spec.js
@@ -3,7 +3,7 @@ const updateJobPage = helper.updateJobPage;
 const googleTagManagerHelper = helper.googleTagManagerHelper;
 const expect = require('chai').expect;
 const progression = require('../../app/models/progression');
-const labels = require('../../app/locales/en.json');
+const labels = helper.labels;
 
 describe('Update a job', () => {
   const accountId = 'c86df559-38b9-4f7c-89b7-794278655bc0';


### PR DESCRIPTION
- [x] showing only 3 initial statuses
- [x] job progression is a required field
- [x] move some tests from cucumber to mocha
- [x] change labels for progression on add/update screens