### PR TITLE
Record outcome of a job as success or failure

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -30,13 +30,15 @@
     "interested": "Interested",
     "applied": "Applied",
     "interview": "Interview",
-    "result": "Result",
     "long": {
       "interested": "Interested",
       "applied": "Applied",
       "interview": "Going for an interview",
-      "result": "Result"
-    }
+      "failure": "I didn't get it",
+      "success": "Offered the job"
+    },
+    "failure": "Unsuccessful",
+    "success": "Successful"
   },
   "addJob": {
     "form": {

--- a/app/models/progression.js
+++ b/app/models/progression.js
@@ -4,7 +4,8 @@ class Progression {
       { id: 'interested', order: 0 },
       { id: 'applied', order: 1 },
       { id: 'interview', order: 2 },
-      { id: 'result', order: 3 },
+      { id: 'failure', order: 3 },
+      { id: 'success', order: 4 },
     ];
   }
 

--- a/app/views/update-job.mustache
+++ b/app/views/update-job.mustache
@@ -13,8 +13,8 @@
 
     <section>
       <h2 class="heading-large" data-test="title">{{title}}</h2>
-      <div class="" data-test="employer">{{employer}}</div>
-      <div class="text-secondary font-xsmall" data-test="source">{{sourceUrl}}</div>
+      <p data-test="employer">{{employer}}</p>
+      <p class="text-secondary font-xsmall" data-test="source">{{sourceUrl}}</p>
     </section>
 
     <form action="{{basePath}}/{{accountId}}/jobs/{{id}}?_method=PATCH" method="POST">

--- a/db/migrations/20170314103641_update-result-status.js
+++ b/db/migrations/20170314103641_update-result-status.js
@@ -1,0 +1,9 @@
+exports.up = (knex) =>
+  knex('jobs')
+    .update({ status: 'failure' })
+    .where({ status: 'result' });
+
+exports.down = (knex) =>
+  knex('jobs')
+    .update({ status: 'result' })
+    .whereIn('status', ['success', 'failure']);

--- a/db/seeds/sort/jobs_seed.js
+++ b/db/seeds/sort/jobs_seed.js
@@ -53,7 +53,7 @@ exports.seed = function (knex) {
           updated_at: moment().subtract(fourDays),
           deadline: moment().add(fourDays),
           rating: '4',
-          status: 'result',
+          status: 'failure',
           status_sort_index: 3,
         },
       ]);

--- a/scripts/seeds/test/job_seed.js
+++ b/scripts/seeds/test/job_seed.js
@@ -115,7 +115,7 @@ exports.seed = function (knex) {
         sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
         deadline: moment().subtract(fortnight).add(fortnight),
         rating: '3',
-        status: 'result',
+        status: 'failure',
         status_sort_index: 3,
       });
     })
@@ -131,7 +131,7 @@ exports.seed = function (knex) {
         sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
         deadline: moment().subtract(fortnight).add(fortnight),
         rating: '3',
-        status: 'result',
+        status: 'failure',
         status_sort_index: 3,
       });
     })
@@ -195,7 +195,7 @@ exports.seed = function (knex) {
         sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
         deadline: moment().subtract(month).add(fortnight),
         rating: '3',
-        status: 'result',
+        status: 'failure',
         status_sort_index: 3,
       });
     })
@@ -259,7 +259,7 @@ exports.seed = function (knex) {
         sourceUrl: 'http://www.indeed.com/kjsdjflisdn',
         deadline: moment().subtract(quarter).add(fortnight),
         rating: '3',
-        status: 'result',
+        status: 'failure',
         status_sort_index: 3,
       });
     });

--- a/test/integration/migration/migrate-result-job-status.spec.js
+++ b/test/integration/migration/migrate-result-job-status.spec.js
@@ -1,0 +1,84 @@
+const helper = require('../support/integration-spec-helper');
+const knex = require('../../../app/db').knex;
+const expect = require('chai').expect;
+
+describe('Migrate jobs result status to failure', () => {
+  function values(obj) {
+    return Object.keys(obj).map(k => obj[k]);
+  }
+
+  describe('migrate', () => {
+    const jobs = {
+      jobResult1: helper.sampleJob({ id: 1, status: 'result' }),
+      jobResult2: helper.sampleJob({ id: 2, status: 'result' }),
+      jobInterested: helper.sampleJob({ id: 3, status: 'interested' }),
+      jobApplied: helper.sampleJob({ id: 4, status: 'applied' }),
+      jobInterview: helper.sampleJob({ id: 5, status: 'interview' }),
+    };
+
+    before(() =>
+      helper.cleanDb()
+        .then(() => helper.createJobsInDb(values(jobs)))
+        .then(() => helper.runDbMigration('20170314103641_update-result-status.js'))
+    );
+
+    it('should migrate jobs in status "result" to status "failure"', () =>
+      knex.select()
+        .whereIn('id', [jobs.jobResult1.id, jobs.jobResult2.id])
+        .table('jobs')
+        .then(result => {
+          expect(result[0].status).to.equal('failure');
+          expect(result[1].status).to.equal('failure');
+        })
+    );
+
+
+    [jobs.jobInterested, jobs.jobApplied, jobs.jobInterview]
+      .forEach(job => {
+        it(`should not migrate jobs in status "${job.status}"`, () =>
+          knex.select()
+            .where({ id: job.id })
+            .table('jobs')
+            .then(result => expect(result[0].status).to.equal(job.status))
+        );
+      });
+  });
+
+  describe('rollback', () => {
+    const jobs = {
+      jobSuccess: helper.sampleJob({ id: 1, status: 'success' }),
+      jobFailure: helper.sampleJob({ id: 2, status: 'failure' }),
+      jobInterested: helper.sampleJob({ id: 3, status: 'interested' }),
+      jobApplied: helper.sampleJob({ id: 4, status: 'applied' }),
+      jobInterview: helper.sampleJob({ id: 5, status: 'interview' }),
+    };
+
+
+    before(() =>
+      helper.cleanDb()
+        .then(() => helper.createJobsInDb(values(jobs)))
+        .then(() => helper.rollbackDbMigration('20170314103641_update-result-status.js'))
+    );
+
+    [jobs.jobSuccess, jobs.jobFailure].forEach(job => {
+      it(`should rollback jobs in status "${job.status}" to status "result"`, () =>
+        knex.select()
+          .where({ id: job.id })
+          .table('jobs')
+          .then(result => {
+            expect(result[0].status).to.equal('result');
+          })
+      );
+    });
+
+    [jobs.jobInterested, jobs.jobApplied, jobs.jobInterview]
+      .forEach(job => {
+        it(`should not rollback jobs in status "${job.status}"`, () =>
+          knex.select()
+            .where({ id: job.id })
+            .table('jobs')
+            .then(result => expect(result[0].status).to.equal(job.status))
+        );
+      });
+  });
+});

--- a/test/integration/support/db-helper.js
+++ b/test/integration/support/db-helper.js
@@ -25,4 +25,14 @@ module.exports = {
   sampleJob(job) {
     return Object.assign({}, sampleJob, job);
   },
+
+  runDbMigration(fileName) {
+    // eslint-disable-next-line global-require
+    return require(`../../../db/migrations/${fileName}`).up(knex);
+  },
+
+  rollbackDbMigration(fileName) {
+    // eslint-disable-next-line global-require
+    return require(`../../../db/migrations/${fileName}`).down(knex);
+  },
 };


### PR DESCRIPTION
- [x] migrate jobs in status `result` to status `failure`
- [x] replace `result` status with `success` and `failure` statuses