### PR TITLE
Revert previous status dates and rework

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -45,6 +45,7 @@ app.use((req, res, next) => {
       govukTemplate:
         '../../vendor/govuk_template_mustache_inheritance/views/layouts/govuk_template',
       googleTagManager: 'partials/google-tag-manager',
+      progressionStatusDates: 'partials/progression-status-dates',
     },
   });
   next();

--- a/app/assets/js/_datepickers.js
+++ b/app/assets/js/_datepickers.js
@@ -1,14 +1,1 @@
-const MobileDetect = require('mobile-detect');
-const $ = require('jquery');
-require('jquery-ui/datepicker');
-
-const md = new MobileDetect(window.navigator.userAgent);
-const enableNativeDatepicker = md.mobile() || md.tablet();
-
-if (enableNativeDatepicker) {
-  $('.datepicker').each(function () {
-    this.type = 'date';
-  });
-} else {
-  $('.datepicker').datepicker({ dateFormat: 'dd/mm/yy' });
-}
+// Use native datepicker throughout

--- a/app/assets/js/_datepickers.js
+++ b/app/assets/js/_datepickers.js
@@ -1,1 +1,27 @@
-// Use native datepicker throughout
+const MobileDetect = require('mobile-detect');
+const $ = require('jquery');
+require('jquery-ui/datepicker');
+
+const md = new MobileDetect(window.navigator.userAgent);
+const enableNativeDatepicker = md.mobile() || md.tablet();
+
+if (!enableNativeDatepicker) {
+  $('.date-real').addClass('hidden');
+  $('.datepicker').removeClass('hidden');
+
+  $('.datepicker').each(function () {
+    const target = $(this).data('altField');
+    const isoDate = $(target).val();
+
+    if (isoDate) {
+      const localDate = new Date(isoDate).toLocaleDateString('en-GB');
+      $(this).val(localDate);
+    }
+
+    $(this).datepicker({
+      dateFormat: 'dd/mm/yy',
+      altField: target,
+      altFormat: 'yy-mm-dd',
+    });
+  });
+}

--- a/app/assets/js/main.js
+++ b/app/assets/js/main.js
@@ -8,9 +8,37 @@ const $blockLabels = $(".block-label input[type='radio'], .block-label input[typ
 // eslint-disable-next-line no-new
 new GOVUK.SelectionButtons($blockLabels);
 
+const hideAllStatusGroups = function () {
+  $('#job-statusDateGroup-deadlineDate').addClass('js-hidden');
+  $('#job-statusDateGroup-applicationDate').addClass('js-hidden');
+  $('#job-statusDateGroup-interviewDate').addClass('js-hidden');
+};
 
 // add-a-job page
 $('label[for="job-sourceType-inPerson"]')
   .click(() => $('#job-sourceUrl-group').addClass('js-hidden'));
 $('label[for="job-sourceType-online"]')
   .click(() => $('#job-sourceUrl-group').removeClass('js-hidden'));
+$('label[for="job-statusType-interested"]')
+  .click(() => {
+    hideAllStatusGroups();
+    $('#job-statusDateGroup-deadlineDate').removeClass('js-hidden');
+  });
+$('label[for="job-statusType-applied"]')
+  .click(() => {
+    hideAllStatusGroups();
+    $('#job-statusDateGroup-applicationDate').removeClass('js-hidden');
+  });
+$('label[for="job-statusType-interview"]')
+  .click(() => {
+    hideAllStatusGroups();
+    $('#job-statusDateGroup-interviewDate').removeClass('js-hidden');
+  });
+$('label[for="job-statusType-success"]')
+  .click(() => {
+    hideAllStatusGroups();
+  });
+$('label[for="job-statusType-failure"]')
+  .click(() => {
+    hideAllStatusGroups();
+  });

--- a/app/controllers/add-job-controller.js
+++ b/app/controllers/add-job-controller.js
@@ -23,6 +23,9 @@ const validator = {
       sourceType: validatorSchema.sourceType,
       rating: validatorSchema.rating,
       status: validatorSchema.initialStatus,
+      deadlineDate: validatorSchema.deadlineDate.allow(''),
+      applicationDate: validatorSchema.applicationDate.allow(''),
+      interviewDate: validatorSchema.interviewDate.allow(''),
       _csrf: validatorSchema.csrfToken,
     },
   }),
@@ -55,6 +58,33 @@ router.post('/', validator.post, csrfProtection, (req, res, next) => {
   });
 
   delete jobData._csrf;
+
+  if (jobData.status === 'interested') {
+    delete jobData.applicationDate;
+    delete jobData.interviewDate;
+
+    if (jobData.deadlineDate === '') {
+      delete jobData.deadlineDate;
+    }
+  }
+
+  if (jobData.status === 'applied') {
+    delete jobData.deadlineDate;
+    delete jobData.interviewDate;
+
+    if (jobData.applicationDate === '') {
+      delete jobData.applicationDate;
+    }
+  }
+
+  if (jobData.status === 'interview') {
+    delete jobData.applicationDate;
+    delete jobData.deadlineDate;
+
+    if (jobData.interviewDate === '') {
+      delete jobData.interviewDate;
+    }
+  }
 
   return new Jobs(jobData).save()
     .then((job) => res.redirect(`${basePath}/${accountId}?focus=${job.id}`))

--- a/app/controllers/add-job-controller.js
+++ b/app/controllers/add-job-controller.js
@@ -59,32 +59,17 @@ router.post('/', validator.post, csrfProtection, (req, res, next) => {
 
   delete jobData._csrf;
 
-  if (jobData.status === 'interested') {
-    delete jobData.applicationDate;
-    delete jobData.interviewDate;
+  const fieldsToDeleteByStatus = {
+    interested: ['applicationDate', 'interviewDate'],
+    applied: ['deadlineDate', 'interviewDate'],
+    interview: ['deadlineDate', 'applicationDate'],
+  };
 
-    if (jobData.deadlineDate === '') {
-      delete jobData.deadlineDate;
-    }
-  }
+  fieldsToDeleteByStatus[jobData.status]
+    .forEach((dateField) => { delete jobData[dateField]; });
 
-  if (jobData.status === 'applied') {
-    delete jobData.deadlineDate;
-    delete jobData.interviewDate;
-
-    if (jobData.applicationDate === '') {
-      delete jobData.applicationDate;
-    }
-  }
-
-  if (jobData.status === 'interview') {
-    delete jobData.applicationDate;
-    delete jobData.deadlineDate;
-
-    if (jobData.interviewDate === '') {
-      delete jobData.interviewDate;
-    }
-  }
+  ['deadlineDate', 'applicationDate', 'interviewDate']
+    .forEach(df => { if (jobData[df] === '') { delete jobData[df]; } });
 
   return new Jobs(jobData).save()
     .then((job) => res.redirect(`${basePath}/${accountId}?focus=${job.id}`))

--- a/app/controllers/add-job-view-model.js
+++ b/app/controllers/add-job-view-model.js
@@ -1,4 +1,5 @@
 const i18n = require('i18n');
+const moment = require('moment');
 const progression = require('../models/progression');
 const ratings = require('../models/ratings');
 const progressionDecorator = require('./progression-view-decorator');
@@ -21,6 +22,12 @@ class AddJobViewModel {
       ],
       body.sourceType
     );
+
+    ['deadlineDate', 'applicationDate', 'interviewDate'].forEach(dateField => {
+      if (this[dateField]) {
+        this[dateField] = moment(this[dateField]).format('YYYY-MM-DD');
+      }
+    });
 
     this.errors = validationErrors;
     this.isSourceUrlHidden = body.sourceType !== 'online';

--- a/app/controllers/jobs-controller.js
+++ b/app/controllers/jobs-controller.js
@@ -90,17 +90,8 @@ router.patch('/:jobId', validator.patch, csrfProtection, (req, res, next) => {
     updateData.status_sort_index = progression.getById(updateData.status).order;
   }
 
-  if (updateData.deadlineDate === '') {
-    delete updateData.deadlineDate;
-  }
-
-  if (updateData.applicationDate === '') {
-    delete updateData.applicationDate;
-  }
-
-  if (updateData.interviewDate === '') {
-    delete updateData.interviewDate;
-  }
+  ['deadlineDate', 'applicationDate', 'interviewDate']
+    .forEach(df => { if (updateData[df] === '') { delete updateData[df]; } });
 
   return new Jobs({ id: jobId })
     .save(updateData, { method: 'update', patch: true })

--- a/app/controllers/progression-view-decorator.js
+++ b/app/controllers/progression-view-decorator.js
@@ -6,6 +6,9 @@ class ProgressionViewDecorator {
       isChecked: (selectedStatus === status),
       // eslint-disable-next-line no-underscore-dangle
       label: i18n.__(`progression.long.${status}`),
+      displayDeadlineDate: status === 'interested',
+      displayApplicationDate: status === 'applied',
+      displayInterviewDate: status === 'interview',
     }));
   }
 }

--- a/app/controllers/validator-schema.js
+++ b/app/controllers/validator-schema.js
@@ -1,4 +1,7 @@
-const Joi = require('joi');
+const BaseJoi = require('joi');
+const Extension = require('joi-date-extensions');
+const Joi = BaseJoi.extend(Extension);
+
 const ratings = require('../models/ratings');
 const progression = require('../models/progression');
 
@@ -12,5 +15,8 @@ module.exports = {
   employer: Joi.string(),
   sourceUrl: Joi.string(),
   sourceType: Joi.any().valid(['inPerson', 'online']),
+  deadlineDate: Joi.string(),
+  applicationDate: Joi.string(),
+  interviewDate: Joi.string(),
   csrfToken: Joi.any(),
 };

--- a/app/controllers/validator-schema.js
+++ b/app/controllers/validator-schema.js
@@ -1,6 +1,4 @@
-const BaseJoi = require('joi');
-const Extension = require('joi-date-extensions');
-const Joi = BaseJoi.extend(Extension);
+const Joi = require('joi');
 
 const ratings = require('../models/ratings');
 const progression = require('../models/progression');
@@ -15,8 +13,8 @@ module.exports = {
   employer: Joi.string(),
   sourceUrl: Joi.string(),
   sourceType: Joi.any().valid(['inPerson', 'online']),
-  deadlineDate: Joi.string(),
-  applicationDate: Joi.string(),
-  interviewDate: Joi.string(),
+  deadlineDate: Joi.date(),
+  applicationDate: Joi.date(),
+  interviewDate: Joi.date(),
   csrfToken: Joi.any(),
 };

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -47,7 +47,10 @@
       "sourceType": "Where did you find out about this job?",
       "sourceUrl": "Website",
       "rating": "How interested are you in this role?",
-      "submit": "Save and continue"
+      "submit": "Save and continue",
+      "deadlineDate": "When is the deadline for applying?",
+      "applicationDate": "When did you apply?",
+      "interviewDate": "When is your interview?"
     },
     "header": "Add a job",
     "linkBack": "Cancel",

--- a/app/views/add-job.mustache
+++ b/app/views/add-job.mustache
@@ -30,11 +30,13 @@
         {{#progression}}
           <div class="form-group">
 
-            <label class="block-label selection-button-radio">{{label}}
-              <input type="radio" value="{{name}}" name="status"
+            <label class="block-label selection-button-radio" for="job-statusType-{{name}}">{{label}}
+              <input id="job-statusType-{{name}}" type="radio" value="{{name}}" name="status"
                      {{#isChecked}}checked{{/isChecked}}>
             </label>
           </div>
+
+          {{>progressionStatusDates}}
         {{/progression}}
       </fieldset>
 

--- a/app/views/partials/progression-status-dates.mustache
+++ b/app/views/partials/progression-status-dates.mustache
@@ -1,0 +1,23 @@
+{{#displayDeadlineDate}}
+  <div id="job-statusDateGroup-deadlineDate" class="form-group panel panel-border-narrow {{^isChecked}}js-hidden{{/isChecked}}">
+    <label class="block" for="job-deadlineDate">{{#__}}addJob.form.deadlineDate{{/__}}</label>
+    <input class="form-control datepicker" data-test="deadlineDate" id="job-deadlineDate"
+           value="{{deadlineDate}}" type="date" name="deadlineDate"  placeholder="dd/mm/yyyy">
+  </div>
+{{/displayDeadlineDate}}
+
+{{#displayApplicationDate}}
+  <div id="job-statusDateGroup-applicationDate" class="form-group panel panel-border-narrow {{^isChecked}}js-hidden{{/isChecked}}">
+    <label class="block" for="job-applicationDate">{{#__}}addJob.form.applicationDate{{/__}}</label>
+    <input class="form-control datepicker" data-test="applicationDate" id="job-applicationDate"
+           value="{{applicationDate}}" type="date" name="applicationDate"  placeholder="dd/mm/yyyy">
+  </div>
+{{/displayApplicationDate}}
+
+{{#displayInterviewDate}}
+  <div id="job-statusDateGroup-interviewDate" class="form-group panel panel-border-narrow {{^isChecked}}js-hidden{{/isChecked}}">
+    <label class="block" for="job-interviewDate">{{#__}}addJob.form.interviewDate{{/__}}</label>
+    <input class="form-control datepicker" data-test="interviewDate" id="job-interviewDate"
+           value="{{interviewDate}}" type="date" name="interviewDate"  placeholder="dd/mm/yyyy">
+  </div>
+{{/displayInterviewDate}}

--- a/app/views/partials/progression-status-dates.mustache
+++ b/app/views/partials/progression-status-dates.mustache
@@ -1,23 +1,23 @@
 {{#displayDeadlineDate}}
   <div id="job-statusDateGroup-deadlineDate" class="form-group panel panel-border-narrow {{^isChecked}}js-hidden{{/isChecked}}">
     <label class="block" for="job-deadlineDate">{{#__}}addJob.form.deadlineDate{{/__}}</label>
-    <input class="form-control datepicker" data-test="deadlineDate" id="job-deadlineDate"
-           value="{{deadlineDate}}" type="date" name="deadlineDate"  placeholder="dd/mm/yyyy">
+    <input class="form-control date-real" id="job-deadlineDate" value="{{deadlineDate}}" data-test="deadlineDate" type="date" name="deadlineDate" placeholder="dd/mm/yyyy">
+    <input class="form-control datepicker hidden" data-alt-field="#job-deadlineDate" data-test="datepicker-deadlineDate" type="text" placeholder="dd/mm/yyyy">
   </div>
 {{/displayDeadlineDate}}
 
 {{#displayApplicationDate}}
   <div id="job-statusDateGroup-applicationDate" class="form-group panel panel-border-narrow {{^isChecked}}js-hidden{{/isChecked}}">
     <label class="block" for="job-applicationDate">{{#__}}addJob.form.applicationDate{{/__}}</label>
-    <input class="form-control datepicker" data-test="applicationDate" id="job-applicationDate"
-           value="{{applicationDate}}" type="date" name="applicationDate"  placeholder="dd/mm/yyyy">
+    <input class="form-control date-real" id="job-applicationDate" value="{{applicationDate}}" data-test="applicationDate" type="date" name="applicationDate" placeholder="dd/mm/yyyy">
+    <input class="form-control datepicker hidden" data-alt-field="#job-applicationDate" data-test="datepicker-applicationDate" type="text" placeholder="dd/mm/yyyy">
   </div>
 {{/displayApplicationDate}}
 
 {{#displayInterviewDate}}
   <div id="job-statusDateGroup-interviewDate" class="form-group panel panel-border-narrow {{^isChecked}}js-hidden{{/isChecked}}">
     <label class="block" for="job-interviewDate">{{#__}}addJob.form.interviewDate{{/__}}</label>
-    <input class="form-control datepicker" data-test="interviewDate" id="job-interviewDate"
-           value="{{interviewDate}}" type="date" name="interviewDate"  placeholder="dd/mm/yyyy">
+    <input class="form-control date-real" id="job-interviewDate" value="{{interviewDate}}" data-test="interviewDate" type="date" name="interviewDate" placeholder="dd/mm/yyyy">
+    <input class="form-control datepicker hidden" data-alt-field="#job-interviewDate" data-test="datepicker-interviewDate" type="text" placeholder="dd/mm/yyyy">
   </div>
 {{/displayInterviewDate}}

--- a/app/views/update-job.mustache
+++ b/app/views/update-job.mustache
@@ -25,11 +25,13 @@
         {{#progression}}
           <div class="form-group">
 
-            <label class="block-label selection-button-radio">{{label}}
-            <input type="radio" value="{{name}}" name="status"
+            <label class="block-label selection-button-radio" for="job-statusType-{{name}}">{{label}}
+            <input id="job-statusType-{{name}}" type="radio" value="{{name}}" name="status"
                    {{#isChecked}}checked{{/isChecked}}>
             </label>
           </div>
+
+          {{>progressionStatusDates}}
         {{/progression}}
       </fieldset>
 

--- a/db/migrations/20170505165219_add_status_dates.js
+++ b/db/migrations/20170505165219_add_status_dates.js
@@ -1,0 +1,13 @@
+exports.up = (knex) =>
+  knex.schema.table('jobs', (table) => {
+    table.date('deadlineDate');
+    table.date('applicationDate');
+    table.date('interviewDate');
+  });
+
+exports.down = (knex) =>
+  knex.schema.table('jobs', (table) => {
+    table.dropColumn('deadlineDate');
+    table.dropColumn('applicationDate');
+    table.dropColumn('interviewDate');
+  });

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2704,18 +2704,6 @@
         }
       }
     },
-    "joi-date-extensions": {
-      "version": "1.0.2",
-      "from": "joi-date-extensions@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/joi-date-extensions/-/joi-date-extensions-1.0.2.tgz",
-      "dependencies": {
-        "hoek": {
-          "version": "4.1.1",
-          "from": "hoek@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz"
-        }
-      }
-    },
     "jquery": {
       "version": "3.2.1",
       "from": "jquery@>=3.0.0 <4.0.0",
@@ -4321,7 +4309,7 @@
     },
     "sha.js": {
       "version": "2.4.8",
-      "from": "sha.js@>=2.4.0 <3.0.0",
+      "from": "sha.js@>=2.3.6 <3.0.0",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz"
     },
     "shasum": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2704,6 +2704,18 @@
         }
       }
     },
+    "joi-date-extensions": {
+      "version": "1.0.2",
+      "from": "joi-date-extensions@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/joi-date-extensions/-/joi-date-extensions-1.0.2.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "4.1.1",
+          "from": "hoek@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz"
+        }
+      }
+    },
     "jquery": {
       "version": "3.2.1",
       "from": "jquery@>=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "hogan.js": "~3.0",
     "i18n": "^0.8.2",
     "joi": "^10.4.1",
-    "joi-date-extensions": "^1.0.2",
     "jquery": "^3.0.0",
     "jquery-ui": "^1.10.5",
     "knex": "^0.11.5",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "fetch-metrics": "./scripts/fetch-metrics",
     "features": "NODE_ENV=test cucumber.js && NODE_ENV=test EXPRESS_BASE_PATH=/example-base-path cucumber.js",
     "heroku-postbuild": "npm run compile",
-    "snyk-protect": "snyk protect",
-    "prepublish": "npm run snyk-protect"
+    "snyk-protect": "snyk protect"
   },
   "// NOTE": [
     "^Pinned dependencies are actually devDependencies, which are only",
@@ -48,6 +47,7 @@
     "hogan.js": "~3.0",
     "i18n": "^0.8.2",
     "joi": "^10.4.1",
+    "joi-date-extensions": "^1.0.2",
     "jquery": "^3.0.0",
     "jquery-ui": "^1.10.5",
     "knex": "^0.11.5",
@@ -84,6 +84,5 @@
   },
   "engines": {
     "node": "6.1.0"
-  },
-  "snyk": true
+  }
 }

--- a/test/common/page_objects/add-job-page.js
+++ b/test/common/page_objects/add-job-page.js
@@ -6,15 +6,9 @@ const AddJobPage = function AddJobPage(browser, app) {
   this.app = app;
 
   this.setStatusDateValues = (data) => {
-    if (data.deadlineDate) {
-      browser.fill('[name="deadlineDate"]', moment(data.deadlineDate).format('YYYY-MM-DD'));
-    }
-    if (data.applicationDate) {
-      browser.fill('[name="applicationDate"]', moment(data.applicationDate).format('YYYY-MM-DD'));
-    }
-    if (data.interviewDate) {
-      browser.fill('[name="interviewDate"]', moment(data.interviewDate).format('YYYY-MM-DD'));
-    }
+    if (data.deadlineDate) { this.setStatusDate('deadlineDate', data.deadlineDate); }
+    if (data.applicationDate) { this.setStatusDate('applicationDate', data.applicationDate); }
+    if (data.interviewDate) { this.setStatusDate('interviewDate', data.interviewDate); }
   };
 
   this.fillJobApplication = (data) => {
@@ -28,6 +22,12 @@ const AddJobPage = function AddJobPage(browser, app) {
       .choose(`#job-rating-${data.rating}`)
       .pressButton('input[type=submit]');
   };
+
+  this.setStatusDate = (dateField, value) =>
+    browser.fill(`[data-test="${dateField}"]`, moment(value).format('YYYY-MM-DD'));
+
+  this.isFormFieldHidden = (dateField) => browser.query(`[data-test="${dateField}"]`)
+    .className.split(/\s+/).includes('hidden');
 
   this.getValidationError = () => browser.text('#validation-errors');
 

--- a/test/common/page_objects/add-job-page.js
+++ b/test/common/page_objects/add-job-page.js
@@ -1,12 +1,26 @@
 const request = require('supertest');
+const moment = require('moment');
 const extractCsrfToken = require('../csrf-token-helper').extractCsrfToken;
 const AddJobPage = function AddJobPage(browser, app) {
   this.browser = browser;
   this.app = app;
 
+  this.setStatusDateValues = (data) => {
+    if (data.deadlineDate) {
+      browser.fill('[name="deadlineDate"]', moment(data.deadlineDate).format('YYYY-MM-DD'));
+    }
+    if (data.applicationDate) {
+      browser.fill('[name="applicationDate"]', moment(data.applicationDate).format('YYYY-MM-DD'));
+    }
+    if (data.interviewDate) {
+      browser.fill('[name="interviewDate"]', moment(data.interviewDate).format('YYYY-MM-DD'));
+    }
+  };
+
   this.fillJobApplication = (data) => {
     this.fillTitle(data.title);
     this.setJobProgression(data.status);
+    this.setStatusDateValues(data);
     return browser
       .fill('[name="employer"]', data.employer)
       .choose(`#job-sourceType-${data.sourceType}`)
@@ -24,6 +38,8 @@ const AddJobPage = function AddJobPage(browser, app) {
   this.chooseSourceType = (sourceType) => browser.choose(`#job-sourceType-${sourceType}`);
   this.isSourceUrlHidden = () =>
     browser.query('#job-sourceUrl-group').className.split(/\s+/).includes('js-hidden');
+  this.isDateSectionHidden = (dateField) =>
+    browser.query(`#job-statusDateGroup-${dateField}`).className.split(/\s+/).includes('js-hidden');
   this.formValues = () =>
     ({
       title: browser.field('[name="title"]').value,
@@ -32,12 +48,15 @@ const AddJobPage = function AddJobPage(browser, app) {
       sourceUrl: browser.field('[name="sourceUrl"]').value,
       rating: browser.field('[name="rating"][checked]').value,
       status: browser.field('[data-test="progression"] input[checked]').value,
+      deadlineDate: browser.field('[data-test="deadlineDate"]').value,
+      applicationDate: browser.field('[data-test="applicationDate"]').value,
+      interviewDate: browser.field('[data-test="interviewDate"]').value,
     });
   this.fillTitle = title => browser.fill('[name="title"]', title);
   this.setJobProgression = (status) => browser
     .click(`[data-test="progression"] input[value="${status}"]`);
   this.getJobProgressionOptions = () =>
-    browser.queryAll('[data-test="progression"] input')
+    browser.queryAll('[data-test="progression"] input[name=status]')
       .map(i => i.value);
   this.getRatings = () =>
     browser.queryAll('input[name="rating"]')

--- a/test/common/page_objects/update-job-page.js
+++ b/test/common/page_objects/update-job-page.js
@@ -42,6 +42,13 @@ const UpdateJobPage = function UpdateJobPage(browser, app) {
         .set({ cookie: res.headers['set-cookie'] })
         .send(Object.assign({}, body, { _csrf: csrfToken }));
     });
+
+  this.isDateSectionHidden = (dateField) =>
+    browser.query(`#job-statusDateGroup-${dateField}`).className.split(/\s+/).includes('js-hidden');
+
+  this.getStatusDate = (dateField) => browser.query(`[data-test="${dateField}"]`).value;
+  this.setStatusDate = (dateField, value) =>
+    browser.fill(`[data-test="${dateField}"]`, value);
 };
 
 module.exports = UpdateJobPage;

--- a/test/common/page_objects/update-job-page.js
+++ b/test/common/page_objects/update-job-page.js
@@ -46,9 +46,11 @@ const UpdateJobPage = function UpdateJobPage(browser, app) {
   this.isDateSectionHidden = (dateField) =>
     browser.query(`#job-statusDateGroup-${dateField}`).className.split(/\s+/).includes('js-hidden');
 
-  this.getStatusDate = (dateField) => browser.query(`[data-test="${dateField}"]`).value;
-  this.setStatusDate = (dateField, value) =>
+  this.getFormField = (dateField) => browser.query(`[data-test="${dateField}"]`).value;
+  this.setFormField = (dateField, value) =>
     browser.fill(`[data-test="${dateField}"]`, value);
+  this.isFormFieldHidden = (dateField) => browser.query(`[data-test="${dateField}"]`)
+    .className.split(/\s+/).includes('hidden');
 };
 
 module.exports = UpdateJobPage;

--- a/test/features/step_definitions/account_steps.js
+++ b/test/features/step_definitions/account_steps.js
@@ -1,10 +1,8 @@
 const JobsModel = require('../../../app/models/jobs-model');
-const moment = require('moment');
 const initialStatus = require('../../../app/models/progression').getAllIds()[0];
 
 function jobDataFormattedForDb(job) {
   return Object.assign({}, job,
-    { deadline: moment(job.deadline, 'DD/MM/YYYY').format() },
     { status: initialStatus }
   );
 }

--- a/test/features/support/fixtures.js
+++ b/test/features/support/fixtures.js
@@ -5,6 +5,7 @@ module.exports = {
     sourceType: 'online',
     sourceUrl: 'http://example.com',
     rating: '4',
-    deadline: '20/10/2016',
+    status: 'interested',
+    deadline: '2016-10-20',
   },
 };

--- a/test/features/support/fixtures.js
+++ b/test/features/support/fixtures.js
@@ -6,6 +6,6 @@ module.exports = {
     sourceUrl: 'http://example.com',
     rating: '4',
     status: 'interested',
-    deadline: '2016-10-20',
+    deadlineDate: '2016-10-20',
   },
 };

--- a/test/integration/add-job-page.spec.js
+++ b/test/integration/add-job-page.spec.js
@@ -274,6 +274,21 @@ describe('Add a job page', () => {
             expect(response.status).to.equal(403);
           })
       );
+
+      ['deadlineDate', 'applicationDate', 'interviewDate'].forEach(d => {
+        const formData = { title: 'title' };
+        formData[d] = '2017_05_12';
+
+        it(`should disallow incorrect ${d} format`, (done) => {
+          addJobPage
+            .postWithCsrfToken(accountId, formData)
+            .then(response => {
+              expect(response.status).to.equal(400);
+              expect(response.text).to.include('We&#39;re experiencing technical problems.');
+              done();
+            });
+        });
+      });
     });
   });
 });

--- a/test/integration/date-field-display.spec.js
+++ b/test/integration/date-field-display.spec.js
@@ -1,0 +1,54 @@
+const helper = require('./support/integration-spec-helper');
+const addJobPage = helper.addJobPage;
+const updateJobPage = helper.updateJobPage;
+const expect = require('chai').expect;
+
+describe('Status date fields', () => {
+  describe('add job date fields', () => {
+    const accountId = '6e253198-3be2-11e7-8c9e-dbdc75f76106';
+
+    before(() => addJobPage.visit(accountId));
+
+    it('should display the correct date field by default', () => {
+      expect(addJobPage.isFormFieldHidden('deadlineDate')).to.equal(true);
+      expect(addJobPage.isFormFieldHidden('datepicker-deadlineDate')).to.equal(false);
+
+      expect(addJobPage.isFormFieldHidden('applicationDate')).to.equal(true);
+      expect(addJobPage.isFormFieldHidden('datepicker-applicationDate')).to.equal(false);
+
+      expect(addJobPage.isFormFieldHidden('interviewDate')).to.equal(true);
+      expect(addJobPage.isFormFieldHidden('datepicker-interviewDate')).to.equal(false);
+    });
+  });
+
+  describe('update job date fields', () => {
+    before(() => {
+      const job = helper.sampleJob(
+        {
+          id: 999,
+          deadlineDate: '2017-12-24',
+          applicationDate: '2017-12-25',
+          interviewDate: '2017-12-26',
+        });
+
+      return helper.cleanDb()
+        .then(() => helper.createJobsInDb(job))
+        .then(() => updateJobPage.visit(job.accountId, job));
+    });
+
+    it('should display the correct date field by default', () => {
+      expect(addJobPage.isFormFieldHidden('deadlineDate')).to.equal(true);
+      expect(addJobPage.isFormFieldHidden('datepicker-deadlineDate')).to.equal(false);
+      expect(updateJobPage.getFormField('deadlineDate')).to.equal('2017-12-24');
+
+      expect(addJobPage.isFormFieldHidden('applicationDate')).to.equal(true);
+      expect(addJobPage.isFormFieldHidden('datepicker-applicationDate')).to.equal(false);
+      expect(updateJobPage.getFormField('applicationDate')).to.equal('2017-12-25');
+
+      expect(addJobPage.isFormFieldHidden('interviewDate')).to.equal(true);
+      expect(addJobPage.isFormFieldHidden('datepicker-interviewDate')).to.equal(false);
+      expect(updateJobPage.getFormField('interviewDate')).to.equal('2017-12-26');
+    });
+  });
+});
+

--- a/test/integration/support/db-helper.js
+++ b/test/integration/support/db-helper.js
@@ -9,7 +9,6 @@ const sampleJob = {
   updated_at: moment(),
   sourceType: 'online',
   sourceUrl: 'http://www.stuff.com',
-  deadline: '2016-07-14',
   rating: '1',
   status: 'applied',
   status_sort_index: 1,
@@ -24,6 +23,9 @@ module.exports = {
   },
   sampleJob(job) {
     return Object.assign({}, sampleJob, job);
+  },
+  findJobInDb(accountId) {
+    return knex('jobs').first().where('accountId', accountId);
   },
 
   runDbMigration(fileName) {

--- a/test/integration/support/db-helper.js
+++ b/test/integration/support/db-helper.js
@@ -11,6 +11,7 @@ const sampleJob = {
   sourceUrl: 'http://www.stuff.com',
   rating: '1',
   status: 'applied',
+  applicationDate: '2017-01-30',
   status_sort_index: 1,
 };
 

--- a/test/integration/update-job.spec.js
+++ b/test/integration/update-job.spec.js
@@ -89,7 +89,7 @@ describe('Update a job', () => {
     );
 
     it('should display job status date', () => {
-      expect(updateJobPage.getStatusDate('applicationDate'))
+      expect(updateJobPage.getFormField('applicationDate'))
         .to.equal(moment(job.applicationDate).format('YYYY-MM-DD'));
     });
   });
@@ -119,10 +119,10 @@ describe('Update a job', () => {
     ].forEach(s => {
       it(`should update ${s.status} status date field ${s.statusDateField}`, () =>
         updateJobPage.setJobProgression('applied')
-          .then(() => updateJobPage.setStatusDate('applicationDate', '2017-12-01'))
+          .then(() => updateJobPage.setFormField('applicationDate', '2017-12-01'))
           .then(() => updateJobPage.clickSave())
           .then(() => helper.dashboardPage.clickUpdateJobButton(job))
-          .then(() => expect(updateJobPage.getStatusDate('applicationDate'))
+          .then(() => expect(updateJobPage.getFormField('applicationDate'))
             .to.equal('2017-12-01')));
     });
   });

--- a/test/integration/update-job.spec.js
+++ b/test/integration/update-job.spec.js
@@ -4,6 +4,7 @@ const googleTagManagerHelper = helper.googleTagManagerHelper;
 const expect = require('chai').expect;
 const progression = require('../../app/models/progression');
 const labels = helper.labels;
+const moment = require('moment');
 
 describe('Update a job', () => {
   const accountId = 'c86df559-38b9-4f7c-89b7-794278655bc0';
@@ -12,6 +13,7 @@ describe('Update a job', () => {
     title: 'Job to update',
     rating: '4',
     status: 'applied',
+    applicationDate: '2017-05-20',
     sourceUrl: 'http://www.stuff.on.the.updated.test.com',
     id: 666,
   });
@@ -30,6 +32,31 @@ describe('Update a job', () => {
     it('should contain valid google tag manager data', () =>
       expect(googleTagManagerHelper.getAccountVariable()).to.equal(accountId)
     );
+
+    [
+      {
+        statusSelected: 'interested',
+        interestedHidden: false, appliedHidden: true, interviewHidden: true,
+      },
+      {
+        statusSelected: 'applied',
+        interestedHidden: true, appliedHidden: false, interviewHidden: true,
+      },
+    ].forEach(s => {
+      it(`should show and hide status date sections when ${s.statusSelected} status chosen`,
+        (done) => {
+          updateJobPage.setJobProgression('interested');
+          updateJobPage.setJobProgression(s.statusSelected);
+
+          expect(updateJobPage.isDateSectionHidden('deadlineDate'))
+            .to.equal(s.interestedHidden, 'interested is hidden?');
+          expect(updateJobPage.isDateSectionHidden('applicationDate'))
+            .to.equal(s.appliedHidden, 'applied is hidden?');
+          expect(updateJobPage.isDateSectionHidden('interviewDate'))
+            .to.equal(s.interviewHidden, 'interview is hidden?');
+          done();
+        });
+    });
   });
 
   describe('job details', () => {
@@ -46,7 +73,7 @@ describe('Update a job', () => {
     );
 
     it('should not display job source when user didn\'t specify source url', () => {
-      const jobWithoutUrl = { id: 911, accountId };
+      const jobWithoutUrl = { id: 911, accountId, status: 'interested' };
       return helper.cleanDb()
         .then(() => helper.createJobsInDb([jobWithoutUrl]))
         .then(() => updateJobPage.visit(accountId, jobWithoutUrl))
@@ -60,6 +87,11 @@ describe('Update a job', () => {
     it('should display job rating', () =>
       expect(updateJobPage.getJobRating()).to.equal(job.rating)
     );
+
+    it('should display job status date', () => {
+      expect(updateJobPage.getStatusDate('applicationDate'))
+        .to.equal(moment(job.applicationDate).format('YYYY-MM-DD'));
+    });
   });
 
   describe('update job details', () => {
@@ -78,6 +110,20 @@ describe('Update a job', () => {
           .then(() => updateJobPage.clickSave())
           .then(() => expect(helper.dashboardPage.getInterestLevel(job)).to.equal(s))
       );
+    });
+
+    [
+      { status: 'interested', statusDateField: 'deadlineDate' },
+      { status: 'applied', statusDateField: 'applicationDate' },
+      { status: 'interview', statusDateField: 'interviewDate' },
+    ].forEach(s => {
+      it(`should update ${s.status} status date field ${s.statusDateField}`, () =>
+        updateJobPage.setJobProgression('applied')
+          .then(() => updateJobPage.setStatusDate('applicationDate', '2017-12-01'))
+          .then(() => updateJobPage.clickSave())
+          .then(() => helper.dashboardPage.clickUpdateJobButton(job))
+          .then(() => expect(updateJobPage.getStatusDate('applicationDate'))
+            .to.equal('2017-12-01')));
     });
   });
 
@@ -122,7 +168,6 @@ describe('Update a job', () => {
           body: { status: progression.getAllIds()[2], rating: '4', incorrect: 'attribute' },
           statusCode: 400,
         },
-
       ].forEach(s => {
         it(`jobId "${s.jobId}" with body: ${JSON.stringify(s.body)} returns ${s.statusCode}`, () =>
           updateJobPage.patchWithCsrfToken(accountId, s.jobId, s.body)


### PR DESCRIPTION
- Attempt to use standard date across the board (e.g. 2017-12-25)
- Remove dates from progression object
- Reimplement status dates across add and update pages
- Implement fix for dates / datepicker