### PR TITLE
Review and resolve rules discussions

### DIFF
--- a/app/rules/timeline-rules-priority.js
+++ b/app/rules/timeline-rules-priority.js
@@ -8,17 +8,17 @@ function atLeastOneJob(jobs) {
 function anyJobYoungerThan21days(jobList) {
   const time21DaysAgo = moment().subtract(21, 'days');
 
-  const jobYoungerThan21days = jobList
-    .find(it => moment(it.statusDate).isAfter(time21DaysAgo, 'day'));
+  if (atLeastOneJob(jobList)) {
+    const jobYoungerThan21days = jobList
+      .find(it => moment(it.statusDate).isAfter(time21DaysAgo, 'day'));
 
-  return jobYoungerThan21days;
+    return jobYoungerThan21days;
+  }
+  return false;
 }
 
 function allDatesOlderThen21days(jobList) {
-  if (atLeastOneJob(jobList)) {
-    return !anyJobYoungerThan21days(jobList);
-  }
-  return true;
+  return !anyJobYoungerThan21days(jobList);
 }
 
 function noJobsWithoutDates(jobList) {

--- a/app/rules/timeline-rules-priority.js
+++ b/app/rules/timeline-rules-priority.js
@@ -38,7 +38,7 @@ function rulesForInterested(jobs) {
 }
 
 function rulesForApplied(jobs) {
-  const rule = atLeastOneJob(jobs) ? 'high' : 'default';
+  const rule = atLeastOneJob(jobs) && anyJobYoungerThan21days(jobs) ? 'high' : 'default';
   return { applied: rule };
 }
 

--- a/app/rules/timeline-rules-priority.js
+++ b/app/rules/timeline-rules-priority.js
@@ -5,13 +5,18 @@ function atLeastOneJob(jobs) {
   return !!jobs && jobs.length > 0;
 }
 
+function anyJobYoungerThan21days(jobList) {
+  const time21DaysAgo = moment().subtract(21, 'days');
+
+  const jobYoungerThan21days = jobList
+    .find(it => moment(it.statusDate).isAfter(time21DaysAgo, 'day'));
+
+  return jobYoungerThan21days;
+}
+
 function allDatesOlderThen21days(jobList) {
   if (atLeastOneJob(jobList)) {
-    const time21DaysAgo = moment().subtract(21, 'days');
-
-    const jobYoungerThen21days = jobList
-      .find(it => moment(it.statusDate).isAfter(time21DaysAgo, 'day'));
-    return !jobYoungerThen21days;
+    return !anyJobYoungerThan21days(jobList);
   }
   return true;
 }
@@ -28,7 +33,7 @@ function groupByStatus(jobList) {
 }
 
 function rulesForInterested(jobs) {
-  const rule = atLeastOneJob(jobs) ? 'high' : 'default';
+  const rule = atLeastOneJob(jobs) && anyJobYoungerThan21days(jobs) ? 'high' : 'default';
   return { interested: rule };
 }
 

--- a/app/rules/timeline-rules-text.js
+++ b/app/rules/timeline-rules-text.js
@@ -36,9 +36,8 @@ function allJobsMoreThenAWeekInTheFuture(jobs) {
   return !jobs.find(it => moment(it.statusDate).isSameOrBefore(weekFromNow(), 'day'));
 }
 
-function allJobsMoreThan21DaysAgo(jobs) {
-  const time21DaysAgo = moment().subtract(21, 'days');
-  return !jobs.find(j => moment(j.statusDate).isAfter(time21DaysAgo, 'day'));
+function allJobsInThePast(jobs) {
+  return !jobs.find(j => moment(j.statusDate).isSameOrAfter(now()));
 }
 
 function findJobsExpiringInLessThanAWeek(jobs) {
@@ -62,7 +61,7 @@ function findJobsExpired(jobs, when = now()) {
 function getTextForInterested(jobs) {
   if (noJobWithStatusDateSet(jobs) ||
       allJobsMoreThenAWeekInTheFuture(jobs) ||
-      allJobsMoreThan21DaysAgo(jobs)) {
+      allJobsInThePast(jobs)) {
     const date = mostRecentUpdatedDate(jobs);
     return [`Updated ${moment(date).fromNow()}`];
   }

--- a/app/rules/timeline-rules-text.js
+++ b/app/rules/timeline-rules-text.js
@@ -36,6 +36,11 @@ function allJobsMoreThenAWeekInTheFuture(jobs) {
   return !jobs.find(it => moment(it.statusDate).isSameOrBefore(weekFromNow(), 'day'));
 }
 
+function allJobsMoreThan21DaysAgo(jobs) {
+  const time21DaysAgo = moment().subtract(21, 'days');
+  return !jobs.find(j => moment(j.statusDate).isAfter(time21DaysAgo, 'day'));
+}
+
 function findJobsExpiringInLessThanAWeek(jobs) {
   return jobs.filter(
     it => moment(it.statusDate).isBetween(now(), weekFromNow(), 'day', '[]')
@@ -55,7 +60,9 @@ function findJobsExpired(jobs, when = now()) {
 }
 
 function getTextForInterested(jobs) {
-  if (noJobWithStatusDateSet(jobs) || allJobsMoreThenAWeekInTheFuture(jobs)) {
+  if (noJobWithStatusDateSet(jobs) ||
+      allJobsMoreThenAWeekInTheFuture(jobs) ||
+      allJobsMoreThan21DaysAgo(jobs)) {
     const date = mostRecentUpdatedDate(jobs);
     return [`Updated ${moment(date).fromNow()}`];
   }

--- a/app/rules/timeline-rules-text.js
+++ b/app/rules/timeline-rules-text.js
@@ -60,7 +60,12 @@ function getTextForInterested(jobs) {
     return [`Updated ${moment(date).fromNow()}`];
   }
 
-  const jobsExpiringSoonCount = findJobsExpiringInLessThanAWeek(jobs).length;
+  const jobsExpiringInLessThanAWeek = findJobsExpiringInLessThanAWeek(jobs);
+  const jobsExpiringInLessThanAWeekWithDeadlineDate =
+    jobsExpiringInLessThanAWeek.filter(j => !!j.deadlineDate);
+
+  const jobsExpiringSoonCount = jobsExpiringInLessThanAWeekWithDeadlineDate.length;
+
   if (jobsExpiringSoonCount === 1) {
     return ['One job expiring soon'];
   }

--- a/test/unit/timeline-rules-priority.spec.js
+++ b/test/unit/timeline-rules-priority.spec.js
@@ -24,6 +24,11 @@ describe('Timeline rules', function () {
           jobs: [aJob({ status: 'interested' })],
           result: 'high',
         },
+        {
+          name: 'default when job list contains date 21 days ago',
+          jobs: [aJob({ status: 'interested', deadlineDate: time21daysAgo })],
+          result: 'default',
+        },
       ].forEach(s => {
         it(s.name, () => {
           expect(rules.priority(s.jobs).interested).to.equal(s.result);

--- a/test/unit/timeline-rules-priority.spec.js
+++ b/test/unit/timeline-rules-priority.spec.js
@@ -40,6 +40,11 @@ describe('Timeline rules', function () {
       [
         { name: 'default for empty list', jobs: [], result: 'default' },
         { name: 'high when there is a job', jobs: [aJob({ status: 'applied' })], result: 'high' },
+        {
+          name: 'default when job list contains date 21 days ago',
+          jobs: [aJob({ status: 'applied', applicationDate: time21daysAgo })],
+          result: 'default',
+        },
       ].forEach(s => {
         it(s.name, () => {
           expect(rules.priority(s.jobs).applied).to.equal(s.result);

--- a/test/unit/timeline-rules-text.spec.js
+++ b/test/unit/timeline-rules-text.spec.js
@@ -70,6 +70,15 @@ describe('Timeline rules', function () {
           ],
           result: ['2 jobs expiring soon'],
         },
+        {
+          name: 'jobs without a deadline date should not be included',
+          jobs: [
+            aJob({ status: 'interested', deadlineDate: in7days, updated_at: now }),
+            aJob({ status: 'interested', updated_at: now }),
+          ],
+          result: ['One job expiring soon'],
+        },
+
 
       ].forEach(s => {
         it(s.name, () => {

--- a/test/unit/timeline-rules-text.spec.js
+++ b/test/unit/timeline-rules-text.spec.js
@@ -15,6 +15,7 @@ describe('Timeline rules', function () {
   const time3weeksAgo = moment().subtract(3, 'weeks').toDate();
   const time3weeksAnd1DayAgo = moment().subtract(22, 'days').toDate();
   const time3weeksAnd2DaysAgo = moment().subtract(23, 'days').toDate();
+  const time21daysAgo = moment().subtract(21, 'days').toDate();
 
   function aJob(opts) {
     return new Job(Object.assign(
@@ -71,6 +72,16 @@ describe('Timeline rules', function () {
           result: ['2 jobs expiring soon'],
         },
         {
+          name: 'updated date when all dates expired more than 21 days ago',
+          jobs: [
+            aJob({ status: 'interested', deadlineDate: time21daysAgo, updated_at: anHourAgo }),
+            aJob({ status: 'interested', deadlineDate: time21daysAgo, updated_at: anHourAgo }),
+            aJob({ status: 'interested', deadlineDate: time21daysAgo, updated_at: anHourAgo }),
+          ],
+          result: ['Updated an hour ago'],
+        },
+
+        {
           name: 'jobs without a deadline date should not be included',
           jobs: [
             aJob({ status: 'interested', deadlineDate: in7days, updated_at: now }),
@@ -111,6 +122,12 @@ describe('Timeline rules', function () {
           ],
           result: ['Last 3 days ago'],
         },
+        {
+          name: 'default when job list contains date 21 days ago',
+          jobs: [aJob({ status: 'applied', applicationDate: time21daysAgo })],
+          result: ['Last 21 days ago'],
+        },
+
       ].forEach(s => {
         it(s.name, () => {
           expect(rules.text(s.jobs).applied).to.eql(s.result);

--- a/test/unit/timeline-rules-text.spec.js
+++ b/test/unit/timeline-rules-text.spec.js
@@ -80,7 +80,6 @@ describe('Timeline rules', function () {
           ],
           result: ['Updated an hour ago'],
         },
-
         {
           name: 'jobs without a deadline date should not be included',
           jobs: [
@@ -89,7 +88,13 @@ describe('Timeline rules', function () {
           ],
           result: ['One job expiring soon'],
         },
-
+        {
+          name: 'updated date when deadline date in the past',
+          jobs: [
+            aJob({ status: 'interested', deadlineDate: time3daysAgo, updated_at: anHourAgo }),
+          ],
+          result: ['Updated an hour ago'],
+        },
 
       ].forEach(s => {
         it(s.name, () => {


### PR DESCRIPTION
- Make sure only interested jobs with deadline dates are considered for text.
- Ensure Interested jobs more than 21 days old return greyed out response
- Ensure Applied jobs more than 21 days old return greyed out response
- Ensure Updated on is displayed for interested deadline dates in the past

Addresses #164 #163 